### PR TITLE
[JENKINS-21494] Add server credentials in env-var settings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
@@ -33,10 +33,11 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.Messages;
+import org.jenkinsci.plugins.configfiles.maven.security.HasServerCredentialMappings;
 import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class GlobalMavenSettingsConfig extends Config {
+public class GlobalMavenSettingsConfig extends Config implements HasServerCredentialMappings {
     private static final long serialVersionUID = 1L;
 
     private List<ServerCredentialMapping> serverCredentialMappings;

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
@@ -34,10 +34,11 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.Messages;
+import org.jenkinsci.plugins.configfiles.maven.security.HasServerCredentialMappings;
 import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class MavenSettingsConfig extends Config {
+public class MavenSettingsConfig extends Config implements HasServerCredentialMappings {
     private static final long serialVersionUID = 1L;
 
     private List<ServerCredentialMapping> serverCredentialMappings;

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/HasServerCredentialMappings.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/HasServerCredentialMappings.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.configfiles.maven.security;
+
+import java.util.List;
+
+/**
+ * Implemented by {@code Config} instances that contain server credential
+ * mappings (Maven settings).
+ */
+public interface HasServerCredentialMappings {
+
+	public abstract List<ServerCredentialMapping> getServerCredentialMappings();
+
+}


### PR DESCRIPTION
The plugin provides global and user settings in Maven Jobs:
- during the Maven build,
- referenced in environment variables, for other job actions such as a Sonar analysis (my use case)

A recent feature also adds credentials defined using the Jenkins Credential plugin, but just in the first case (for the Maven build).
This pull request adds credential mappings in the settings generated separately to be referenced in environment variables.

I tested in both user and global settings, but not knowing much of the Jenkins plugin tests, I did not have the time to investigate on providing unit tests. Maybe later.
