### PR TITLE
[FIXED JENKINS-26339] SimpleBuildWrapper support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.599</version>
+        <version>1.609.1</version>
     </parent>
 
     <artifactId>config-file-provider</artifactId>
@@ -27,7 +27,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <workflow.version>1.2-SNAPSHOT</workflow.version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
+        <workflow.version>1.8</workflow.version>
     </properties>
 
     <developers>
@@ -60,38 +60,45 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>1.3-20150216.230634-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>1.3-20150216.230541-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>1.3-20150216.230609-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>1.3-20150216.230548-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>1.3-20150216.230508-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>1.3-20150216.230528-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- JenkinsRuleExt -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <workflow.version>1.2-SNAPSHOT</workflow.version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
     </properties>
 
     <developers>
@@ -39,7 +40,12 @@
             <name>Dominik Bartholdi</name>
         </developer>
     </developers>
-
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -49,7 +55,45 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.9.1</version>
+            <version>1.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- StepConfigTester -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- SemaphoreStep -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.598-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
+        <version>1.599</version>
     </parent>
 
     <artifactId>config-file-provider</artifactId>
@@ -60,38 +60,38 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230634-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230541-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230609-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230548-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230508-1</version> <!-- TODO ${workflow.version} -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230528-1</version> <!-- TODO ${workflow.version} -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.532</version>
+        <version>1.598-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
     </parent>
 
     <artifactId>config-file-provider</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep.java
@@ -14,7 +14,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +54,7 @@ public class ConfigFileBuildStep extends Builder implements Serializable {
             throw new IllegalStateException("the workspace does not yet exist, can't provision config files - maybe slave is offline?");
         }
 
-        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, listener);
+        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, build.getWorkspace(), listener);
         // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
         build.addAction(new CleanTempFilesAction(file2Path));
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -56,13 +56,12 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
 
     @Override public void setUp(Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, workspace, listener);
-        context.env = new EnvVars();
         List<String> tempFiles = new ArrayList<String>();
         for (Map.Entry<ManagedFile, FilePath> entry : file2Path.entrySet()) {
             ManagedFile mf = entry.getKey();
             FilePath fp = entry.getValue();
             if (!StringUtils.isBlank(mf.variable)) {
-                context.env.put(mf.variable, fp.getRemote());
+                context.env(mf.variable, fp.getRemote());
             }
             boolean noTargetGiven = StringUtils.isBlank(entry.getKey().targetLocation);
             if (noTargetGiven) {
@@ -70,7 +69,7 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
             }
         }
         if (!tempFiles.isEmpty()) {
-            context.disposer = new TempFileCleaner(tempFiles);
+            context.setDisposer(new TempFileCleaner(tempFiles));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -69,7 +69,9 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
                 tempFiles.add(entry.getValue().getRemote());
             }
         }
-        context.disposer = new TempFileCleaner(tempFiles);
+        if (!tempFiles.isEmpty()) {
+            context.disposer = new TempFileCleaner(tempFiles);
+        }
     }
 
     public List<ManagedFile> getManagedFiles() {

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -23,32 +23,29 @@
  */
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.tasks.BuildWrapper;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapperDescriptor;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import jenkins.tasks.SimpleBuildWrapper;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class ConfigFileBuildWrapper extends BuildWrapper {
+public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
 
     private List<ManagedFile> managedFiles = new ArrayList<ManagedFile>();
 
@@ -57,22 +54,22 @@ public class ConfigFileBuildWrapper extends BuildWrapper {
         this.managedFiles = managedFiles;
     }
 
-    @Override
-    public Environment setUp(@SuppressWarnings("rawtypes") AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-
-        final PrintStream logger = listener.getLogger();
-
-        if (build.getWorkspace() == null) {
-            throw new IllegalStateException("the workspace does not yet exist, can't provision config files - maybe slave is offline?");
+    @Override public void setUp(Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
+        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, workspace, listener);
+        context.env = new EnvVars();
+        List<String> tempFiles = new ArrayList<String>();
+        for (Map.Entry<ManagedFile, FilePath> entry : file2Path.entrySet()) {
+            ManagedFile mf = entry.getKey();
+            FilePath fp = entry.getValue();
+            if (!StringUtils.isBlank(mf.variable)) {
+                context.env.put(mf.variable, fp.getRemote());
+            }
+            boolean noTargetGiven = StringUtils.isBlank(entry.getKey().targetLocation);
+            if (noTargetGiven) {
+                tempFiles.add(entry.getValue().getRemote());
+            }
         }
-
-        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, listener);
-        // JENKINS-17555 this special env is required, as MavenModuleSetBuild only takes Environments from BuildWrapper into account, but not those from Actions registered by them.
-        final ManagedFilesEnvironment env = new ManagedFilesEnvironment(file2Path);
-        // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
-        build.addAction(new CleanTempFilesAction(file2Path));
-
-        return env;
+        context.disposer = new TempFileCleaner(tempFiles);
     }
 
     public List<ManagedFile> getManagedFiles() {
@@ -102,42 +99,23 @@ public class ConfigFileBuildWrapper extends BuildWrapper {
 
     }
 
-    /**
-     * fix for JENKINS-17555
-     */
-    public class ManagedFilesEnvironment extends Environment {
-        private final Map<ManagedFile, FilePath> file2Path;
+    private static class TempFileCleaner extends Disposer {
 
-        public ManagedFilesEnvironment(Map<ManagedFile, FilePath> file2Path) {
-            this.file2Path = file2Path == null ? Collections.<ManagedFile, FilePath> emptyMap() : file2Path;
+        private static final long serialVersionUID = 1;
+
+        private final List<String> tempFiles;
+
+        TempFileCleaner(List<String> tempFiles) {
+            this.tempFiles = tempFiles;
         }
 
-        @Override
-        public void buildEnvVars(Map<String, String> env) {
-            for (Map.Entry<ManagedFile, FilePath> entry : file2Path.entrySet()) {
-                ManagedFile mf = entry.getKey();
-                FilePath fp = entry.getValue();
-                if (!StringUtils.isBlank(mf.variable)) {
-                    env.put(mf.variable, fp.getRemote());
-                }
+        @Override public void tearDown(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+            listener.getLogger().println("Deleting " + tempFiles.size() + " temporary files");
+            for (String tempFile : tempFiles) {
+                new FilePath(workspace, tempFile).delete();
             }
         }
 
-        /**
-         * Provides access to the files which have to be removed after the build
-         * 
-         * @return a list of paths to the temp files (remotes)
-         */
-        List<String> getTempFiles() {
-            List<String> tempFiles = new ArrayList<String>();
-            for (Entry<ManagedFile, FilePath> entry : file2Path.entrySet()) {
-                boolean noTargetGiven = StringUtils.isBlank(entry.getKey().targetLocation);
-                if (noTargetGiven) {
-                    tempFiles.add(entry.getValue().getRemote());
-                }
-            }
-            return tempFiles;
-        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -103,7 +103,7 @@ public class ManagedFileUtil {
                 
                 String expandedTargetLocation = managedFile.targetLocation;
                 try {
-                	expandedTargetLocation = build instanceof AbstractBuild ? TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, managedFile.targetLocation) : managedFile.targetLocation;
+                    expandedTargetLocation = build instanceof AbstractBuild ? TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, managedFile.targetLocation) : managedFile.targetLocation;
                 } catch (MacroEvaluationException e) {
                     listener.getLogger().println("[ERROR] failed to expand variables in target location '" + managedFile.targetLocation + "' : " + e.getMessage());
                     expandedTargetLocation = managedFile.targetLocation;

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -24,9 +24,7 @@
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
 import hudson.FilePath;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
-import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 
 import java.io.ByteArrayInputStream;
@@ -45,14 +43,17 @@ import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.security.MasterToSlaveCallable;
 
 public class ManagedFileUtil {
 
     /**
-     * creates a tmp file on the given channel
+     * Seems to be like {@link FilePath#createTempFile}, but passing the 2-arg form to File to use {@code ${java.io.tmpdir}}.
      */
     public static FilePath createTempFile(VirtualChannel channel) throws IOException, InterruptedException {
-        return channel.call(new Callable<FilePath, IOException>() {
+        return channel.call(new MasterToSlaveCallable<FilePath, IOException>() {
             public FilePath call() throws IOException {
                 final File tmpTarget = File.createTempFile("config", "tmp");
                 return new FilePath(tmpTarget);
@@ -76,7 +77,7 @@ public class ManagedFileUtil {
      * @throws InterruptedException
      * @throws
      */
-    public static Map<ManagedFile, FilePath> provisionConfigFiles(List<ManagedFile> managedFiles, AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
+    public static Map<ManagedFile, FilePath> provisionConfigFiles(List<ManagedFile> managedFiles, Run<?,?> build, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
 
         final Map<ManagedFile, FilePath> file2Path = new HashMap<ManagedFile, FilePath>();
         listener.getLogger().println("provisoning config files...");
@@ -97,12 +98,12 @@ public class ManagedFileUtil {
 
             FilePath target = null;
             if (createTempFile) {
-                target = ManagedFileUtil.createTempFile(build.getWorkspace().getChannel());
+                target = ManagedFileUtil.createTempFile(workspace.getChannel());
             } else {
                 
                 String expandedTargetLocation = managedFile.targetLocation;
                 try {
-                    expandedTargetLocation = TokenMacro.expandAll(build, listener, managedFile.targetLocation);
+                	expandedTargetLocation = build instanceof AbstractBuild ? TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, managedFile.targetLocation) : managedFile.targetLocation;
                 } catch (MacroEvaluationException e) {
                     listener.getLogger().println("[ERROR] failed to expand variables in target location '" + managedFile.targetLocation + "' : " + e.getMessage());
                     expandedTargetLocation = managedFile.targetLocation;
@@ -110,7 +111,7 @@ public class ManagedFileUtil {
                 
                 // Should treat given path as the actual filename unless it has a trailing slash (implying a
                 // directory) or path already exists in workspace as a directory.
-                target = new FilePath(build.getWorkspace(), expandedTargetLocation);
+                target = new FilePath(workspace, expandedTargetLocation);
                 String immediateFileName = expandedTargetLocation.substring(
                 		expandedTargetLocation.lastIndexOf("/")+1);
 
@@ -133,12 +134,12 @@ public class ManagedFileUtil {
         return file2Path;
     }
 
-    private static String insertCredentialsInSettings(AbstractBuild<?, ?> build, Config configFile) throws IOException {
+    private static String insertCredentialsInSettings(Run<?,?> build, Config configFile) throws IOException {
 		String fileContent = configFile.content;
 		
 		if (configFile instanceof HasServerCredentialMappings) {
 			HasServerCredentialMappings settings = (HasServerCredentialMappings) configFile;
-			final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build.getProject(), settings.getServerCredentialMappings());
+			final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build.getParent(), settings.getServerCredentialMappings());
 			
 			if (!resolvedCredentials.isEmpty()) {
 				try {

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
@@ -29,6 +29,7 @@ import jenkins.tasks.SimpleBuildWrapper;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
+import org.jenkinsci.plugins.workflow.JenkinsRuleExt;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -92,17 +93,13 @@ public class ConfigFileBuildWrapperWorkflowTest {
             }
         });
         story.addStep(new Statement() {
-            @SuppressWarnings("SleepWhileInLoop")
             @Override public void evaluate() throws Throwable {
                 SemaphoreStep.success("withTempFilesAfterRestart/1", null);
                 WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 assertNotNull(p);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertNotNull(b);
-                while (b.isBuilding()) { // TODO JENKINS-26399 need utility in JenkinsRule
-                    Thread.sleep(100);
-                }
-                story.j.assertBuildStatusSuccess(b);
+                story.j.assertBuildStatusSuccess(JenkinsRuleExt.waitForCompletion(b));
                 story.j.assertLogContains("some content", b);
                 story.j.assertLogContains("Deleting 1 temporary files", b);
             }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.configfiles.buildwrapper;
+
+import java.util.Collections;
+import jenkins.tasks.SimpleBuildWrapper;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.CoreWrapperStep;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class ConfigFileBuildWrapperWorkflowTest {
+
+    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Test public void configRoundTrip() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                String id = createConfig().id;
+                CoreWrapperStep step = new CoreWrapperStep(new ConfigFileBuildWrapper(Collections.singletonList(new ManagedFile(id, "myfile.txt", "MYFILE"))));
+                step = new StepConfigTester(story.j).configRoundTrip(step);
+                SimpleBuildWrapper delegate = step.getDelegate();
+                assertTrue(String.valueOf(delegate), delegate instanceof ConfigFileBuildWrapper);
+                ConfigFileBuildWrapper w = (ConfigFileBuildWrapper) delegate;
+                assertEquals("[[ManagedFile: id=" + id + ", targetLocation=myfile.txt, variable=MYFILE]]", w.getManagedFiles().toString());
+            }
+        });
+    }
+
+    @Test public void withTargetLocation() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt']]]) {\n"
+                        + "    sh 'cat myfile.txt'\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("some content", b);
+                story.j.assertLogNotContains("temporary files", b);
+            }
+        });
+    }
+
+    @Test public void withTempFilesAfterRestart() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + createConfig().id + "', variable: 'MYFILE']]]) {\n"
+                        + "    semaphore 'withTempFilesAfterRestart'\n"
+                        + "    sh 'cat $MYFILE'\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("withTempFilesAfterRestart/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @SuppressWarnings("SleepWhileInLoop")
+            @Override public void evaluate() throws Throwable {
+                SemaphoreStep.success("withTempFilesAfterRestart/1", null);
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                assertNotNull(p);
+                WorkflowRun b = p.getBuildByNumber(1);
+                assertNotNull(b);
+                while (b.isBuilding()) { // TODO JENKINS-26399 need utility in JenkinsRule
+                    Thread.sleep(100);
+                }
+                story.j.assertBuildStatusSuccess(b);
+                story.j.assertLogContains("some content", b);
+                story.j.assertLogContains("Deleting 1 temporary files", b);
+            }
+        });
+    }
+
+    private Config createConfig() {
+        ConfigProvider configProvider = story.j.jenkins.getExtensionList(ConfigProvider.class).get(CustomConfig.CustomConfigProvider.class);
+        String id = configProvider.getProviderId() + "myfile";
+        Config config = new CustomConfig(id, "My File", "", "some content");
+        configProvider.save(config);
+        return config;
+    }
+
+}


### PR DESCRIPTION
[JENKINS-26339](https://issues.jenkins-ci.org/browse/JENKINS-26339): let this plugin be used from workflows.

Should supersede #8, which as a `SimpleBuildStep` has no way of cleaning up temp files when it is done.

- [x] sketch of change
- [x] functional test
- [x] manual testing
- [x] use released version of Workflow
- [x] use (LTS?) release of Jenkins core when SPI merged

@reviewbybees