### PR TITLE
Support user defined configuration file ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ work
 target
 *.iml
 /work2
+
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.modules</groupId>
+            <artifactId>sshd</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 
 /**
@@ -59,8 +60,8 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
     }
 
     @Override
-    public Config newConfig() {
-        String id = this.getProviderId() + "." + System.currentTimeMillis();
+    public Config newConfig(String idSuffix) {
+        String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
         return new Config(id, null, null, null);
     }
 

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.lib.configprovider;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.XmlFile;
 import hudson.model.listeners.SaveableListener;
@@ -59,8 +60,14 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
         return configId != null && configId.startsWith(getProviderId());
     }
 
+    @Deprecated
     @Override
-    public Config newConfig(String idSuffix) {
+    public Config newConfig() {
+        return newConfig(String.valueOf(System.currentTimeMillis()));
+    }
+
+    @Override
+    public Config newConfig(@NonNull String idSuffix) {
         String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
         return new Config(id, null, null, null);
     }

--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -63,7 +63,8 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
     @Deprecated
     @Override
     public Config newConfig() {
-        return newConfig(String.valueOf(System.currentTimeMillis()));
+        String id = this.getProviderId() + "." + System.currentTimeMillis();
+        return new Config(id, null, null, null);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -109,11 +109,35 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
     public abstract String getProviderId();
 
     /**
-     * Returns a new {@link Config} object with a unique id, starting with the id of this provider - separated by '.'. e.g. "MyCustomProvider.123456". This object is also used initialize the user
-     * interface.
+     * <p>
+     *     Returns a new {@link Config} object with a unique id.
+     * </p>
+     *
+     * The unique identifier is composed of:
+     * <ul>
+     *     <li>id of this provider ({@link ConfigProvider#getProviderId()})</li>
+     *     <li>"{@code .}" separator</li>
+     *     <li>
+     *         Given {@code idSuffix} or, if the {@code idSuffix} is {@code null} or empty, a random number based on
+     *         {@link System#currentTimeMillis()}
+     *     </li>
+     * </ul>
+     *
+     * <p>
+     *     This object is also used initialize the user interface.
+     * </p>
+     *
+     * <p>
+     *     Sample generated identifiers "{@code org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.my-id-suffix}"
+     *     or "{@code org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.1234567890}"
+     * </p>
+     *
+     *
+     * @param idSuffix
+     *           nullable suffix of the id of the created config file
      * 
      * @return the new config object, ready for editing.
      */
-    public abstract Config newConfig();
+    public abstract Config newConfig(String idSuffix);
 
 }

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.lib.configprovider;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Descriptor;
@@ -109,6 +110,16 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
     public abstract String getProviderId();
 
     /**
+     * Returns a new {@link Config} object with a unique id, starting with the id of this provider - separated by '.'. e.g. "MyCustomProvider.123456". This object is also used initialize the user
+     * interface.
+     *
+     * @return the new config object, ready for editing.
+     * @deprecated use {@link #newConfig(String)}
+     */
+    @Deprecated
+    public abstract Config newConfig();
+
+    /**
      * <p>
      *     Returns a new {@link Config} object with a unique id.
      * </p>
@@ -118,7 +129,7 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
      *     <li>id of this provider ({@link ConfigProvider#getProviderId()})</li>
      *     <li>"{@code .}" separator</li>
      *     <li>
-     *         Given {@code idSuffix} or, if the {@code idSuffix} is {@code null} or empty, a random number based on
+     *         Given {@code idSuffix} or, if the {@code idSuffix} is empty, a random number based on
      *         {@link System#currentTimeMillis()}
      *     </li>
      * </ul>
@@ -134,10 +145,10 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
      *
      *
      * @param idSuffix
-     *           nullable suffix of the id of the created config file
+     *           suffix of the id of the created config file
      * 
      * @return the new config object, ready for editing.
      */
-    public abstract Config newConfig(String idSuffix);
+    public abstract Config newConfig(@NonNull String idSuffix);
 
 }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
@@ -188,14 +188,14 @@ public class ConfigFilesManagement extends ManagementLink {
      * @throws IOException
      * @throws ServletException
      */
-    public void doAddConfig(StaplerRequest req, StaplerResponse rsp, @QueryParameter("providerId") String providerId) throws IOException, ServletException {
+    public void doAddConfig(StaplerRequest req, StaplerResponse rsp, @QueryParameter("configIdSuffix") String configIdSuffix, @QueryParameter("providerId") String providerId) throws IOException, ServletException {
         checkPermission(Hudson.ADMINISTER);
 
         for (ConfigProvider provider : ConfigProvider.all()) {
             if (provider.getProviderId().equals(providerId)) {
                 req.setAttribute("contentType", provider.getContentType());
                 req.setAttribute("provider", provider);
-                Config config = provider.newConfig();
+                Config config = provider.newConfig(configIdSuffix);
                 req.setAttribute("config", config);
                 break;
             }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
@@ -183,6 +183,8 @@ public class ConfigFilesManagement extends ManagementLink {
      *            request
      * @param rsp
      *            response
+     * @param configIdSuffix
+     *            the suffix of the id of the created configuration object
      * @param providerId
      *            the id of the provider to create a new config instance with
      * @throws IOException

--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
@@ -31,7 +31,9 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
+import hudson.Extension;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -41,7 +43,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import hudson.Extension;
 import hudson.model.Hudson;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
@@ -197,7 +198,12 @@ public class ConfigFilesManagement extends ManagementLink {
             if (provider.getProviderId().equals(providerId)) {
                 req.setAttribute("contentType", provider.getContentType());
                 req.setAttribute("provider", provider);
-                Config config = provider.newConfig(configIdSuffix);
+                Config config;
+                if (hudson.Util.isOverridden(AbstractConfigProviderImpl.class, provider.getClass(), "newConfig", String.class)) {
+                    config = provider.newConfig(configIdSuffix);
+                } else {
+                    config = provider.newConfig();
+                }
                 req.setAttribute("config", config);
                 break;
             }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.custom;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
@@ -57,7 +58,7 @@ public class CustomConfig extends Config {
         }
 
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "MyCustom", "", "");
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.configfiles.custom;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -56,8 +57,8 @@ public class CustomConfig extends Config {
         }
 
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "MyCustom", "", "");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.configfiles.groovy;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -57,8 +58,8 @@ public class GroovyScript extends Config {
         }
 
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "GroovyConfig", "", "println('hello world')");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.groovy;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
@@ -58,7 +59,7 @@ public class GroovyScript extends Config {
         }
 
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "GroovyConfig", "", "println('hello world')");
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.configfiles.json;
 
 import hudson.Extension;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -92,8 +93,8 @@ public class JsonConfig extends Config {
         }
 
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "JsonConfig", "", "{}");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.json;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 
 import org.apache.commons.lang.StringUtils;
@@ -93,7 +94,7 @@ public class JsonConfig extends Config {
         }
 
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "JsonConfig", "", "{}");
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/AbstractMavenSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/AbstractMavenSettingsProvider.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.configfiles.maven;
 import java.io.InputStream;
 
 import hudson.util.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -37,8 +38,8 @@ import org.jenkinsci.lib.configprovider.model.ContentType;
 public abstract class AbstractMavenSettingsProvider extends AbstractConfigProviderImpl {
 
     @Override
-    public Config newConfig() {
-        String id = this.getProviderId() + System.currentTimeMillis();
+    public Config newConfig(String idSuffix) {
+        String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
         return new Config(id, "MySettings", "", loadTemplateContent());
     }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/AbstractMavenSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/AbstractMavenSettingsProvider.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.configfiles.maven;
 
 import java.io.InputStream;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
@@ -38,7 +39,7 @@ import org.jenkinsci.lib.configprovider.model.ContentType;
 public abstract class AbstractMavenSettingsProvider extends AbstractConfigProviderImpl {
 
     @Override
-    public Config newConfig(String idSuffix) {
+    public Config newConfig(@NonNull String idSuffix) {
         String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
         return new Config(id, "MySettings", "", loadTemplateContent());
     }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
@@ -87,7 +88,7 @@ public class GlobalMavenSettingsConfig extends Config implements HasServerCreden
         }
         
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new GlobalMavenSettingsConfig(id, "MyGlobalSettings", "global settings", loadTemplateContent(), GlobalMavenSettingsConfig.isReplaceAllDefault, Collections.<ServerCredentialMapping>emptyList());
         }               

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
@@ -30,6 +30,7 @@ import java.util.List;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.Messages;
@@ -86,8 +87,8 @@ public class GlobalMavenSettingsConfig extends Config implements HasServerCreden
         }
         
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new GlobalMavenSettingsConfig(id, "MyGlobalSettings", "global settings", loadTemplateContent(), GlobalMavenSettingsConfig.isReplaceAllDefault, Collections.<ServerCredentialMapping>emptyList());
         }               
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class MavenSettingsConfig extends Config implements HasServerCredentialMa
         }
         
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new MavenSettingsConfig(id, "MySettings", "user settings", loadTemplateContent(), MavenSettingsConfig.isReplaceAllDefault, Collections.<ServerCredentialMapping>emptyList());
         }        

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.Messages;
@@ -83,8 +84,8 @@ public class MavenSettingsConfig extends Config implements HasServerCredentialMa
         }
         
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new MavenSettingsConfig(id, "MySettings", "user settings", loadTemplateContent(), MavenSettingsConfig.isReplaceAllDefault, Collections.<ServerCredentialMapping>emptyList());
         }        
         

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 
 import java.io.InputStream;
@@ -70,7 +71,7 @@ public class MavenToolchainsConfig extends Config {
          * @see org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl#newConfig()
          */
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "MyToolchains", "", loadTemplateContent());
          }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -69,8 +70,8 @@ public class MavenToolchainsConfig extends Config {
          * @see org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl#newConfig()
          */
         @Override
-        public Config newConfig() {
-            String id = this.getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "MyToolchains", "", loadTemplateContent());
          }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.configfiles.xml;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -56,8 +57,8 @@ public class XmlConfig extends Config {
         }
 
         @Override
-        public Config newConfig() {
-            String id = getProviderId() + System.currentTimeMillis();
+        public Config newConfig(String idSuffix) {
+            String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "XmlConfig", "", "<root></root>");
         }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.xml;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 
@@ -57,7 +58,7 @@ public class XmlConfig extends Config {
         }
 
         @Override
-        public Config newConfig(String idSuffix) {
+        public Config newConfig(@NonNull String idSuffix) {
             String id =  this.getProviderId() + "." + StringUtils.defaultIfBlank(idSuffix, String.valueOf(System.currentTimeMillis()));
             return new Config(id, "XmlConfig", "", "<root></root>");
         }

--- a/src/main/resources/org/jenkinsci/lib/configprovider/model/Config/id-name-and-comment.jelly
+++ b/src/main/resources/org/jenkinsci/lib/configprovider/model/Config/id-name-and-comment.jelly
@@ -1,7 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License
 
-Copyright (c) 2013, Dominik Bartholdi
+Copyright 2015 Jesse Glick.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,33 +23,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-
-
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" >
-<style type="text/css">
-div.credentialssection {
-  border-bottom: 1px solid black;
-}
-</style>
-			<j:set var="descriptor" value="${config.descriptor}"/>
-			<j:set var="instance" value="${config}"/>
-	   		<p>
-	   		 ${%description}
-	   		</p>
-            <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-
-            <f:entry title="${%Replace All}" field="isReplaceAll">
-                <f:checkbox default="true" value="${config.isReplaceAll}"/>
-            </f:entry>
-
-			<f:entry title="${%Server Credentials}">
-                  <f:repeatableProperty field="serverCredentialMappings" />
-			</f:entry>
-                     
-            <f:entry title="${%Content}">
-                <f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-            </f:entry>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%ID}" >
+        <f:textbox readonly="readonly" name="config.id" value="${config.id}" />
+    </f:entry>
+    <f:entry title="${%Name}">
+        <f:textbox name="config.name" value="${config.name}" />
+    </f:entry>
+    <f:entry title="${%Comment}">
+        <f:textbox name="config.comment" value="${config.comment}" />
+    </f:entry>
 </j:jelly>
-
-

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit-config.jelly
@@ -27,15 +27,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 			   		DOMI
-					<f:entry title="${%ID}" >
-						<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-					</f:entry>
-					<f:entry title="${%Name}">
-						<f:textbox name="config.name" value="${config.name}" />
-					</f:entry>
-					<f:entry title="${%Comment}">
-						<f:textbox name="config.comment" value="${config.comment}" />
-					</f:entry>
+					<j:set var="descriptor" value="${config.descriptor}"/>
+					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+
 					<f:entry title="${%Content}">
 						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
 					</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
@@ -35,9 +35,6 @@ THE SOFTWARE.
 			</h1>
 			<j:out value="${%selectprovider}" />
 			<f:form method="post" action="addConfig">
-				<f:entry title="${%ID suffix}" description="${%configIdSuffixDescription}">
-					<f:textbox name="configIdSuffix"/>
-				</f:entry>
 				<f:entry>
 					<table width="100%">
 						<j:forEach var="provider" items="${providers}" varStatus="loop">
@@ -59,6 +56,9 @@ THE SOFTWARE.
 							</tr>
 						</j:forEach>
 					</table>
+				</f:entry>
+				<f:entry title="${%ID suffix}" description="${%configIdSuffixDescription}">
+					<f:textbox name="configIdSuffix"/>
 				</f:entry>
 				<f:block>
 					<f:submit value="${%Submit}" />

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
@@ -57,6 +57,11 @@ THE SOFTWARE.
 						</j:forEach>
 					</table>
 				</f:entry>
+				<f:advanced>
+					<f:entry title="${%ID suffix}" description="${%configIdSuffixDescription}">
+						<f:textbox name="configIdSuffix"/>
+					</f:entry>
+				</f:advanced>
 				<f:block>
 					<f:submit value="${%Submit}" />
 				</f:block>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
@@ -35,6 +35,9 @@ THE SOFTWARE.
 			</h1>
 			<j:out value="${%selectprovider}" />
 			<f:form method="post" action="addConfig">
+				<f:entry title="${%ID suffix}" description="${%configIdSuffixDescription}">
+					<f:textbox name="configIdSuffix"/>
+				</f:entry>
 				<f:entry>
 					<table width="100%">
 						<j:forEach var="provider" items="${providers}" varStatus="loop">
@@ -57,11 +60,6 @@ THE SOFTWARE.
 						</j:forEach>
 					</table>
 				</f:entry>
-				<f:advanced>
-					<f:entry title="${%ID suffix}" description="${%configIdSuffixDescription}">
-						<f:textbox name="configIdSuffix"/>
-					</f:entry>
-				</f:advanced>
 				<f:block>
 					<f:submit value="${%Submit}" />
 				</f:block>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
@@ -18,4 +18,4 @@
 
 selectprovider=Select the file type you want to create
 filetype=Type
-configIdSuffixDescription=Config file ID is prefixed by the provider name (e.g. "org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig") and suffixed by the given "ID suffix" or by a random number if no "ID Suffix" is specified
+configIdSuffixDescription=Optional. Config file ID is prefixed by the provider name (e.g. "org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig") and suffixed by the given "ID suffix" or by a random number if no "ID suffix" is specified

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
@@ -18,4 +18,4 @@
 
 selectprovider=Select the file type you want to create
 filetype=Type
-
+configIdSuffixDescription=Config file ID is prefixed by the provider name (e.g. "org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig") and suffixed by the given "ID suffix" or by a random number if no "ID Suffix" is specified

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/edit-config.jelly
@@ -26,16 +26,10 @@ THE SOFTWARE.
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-			   		
-					<f:entry title="${%ID}" >
-						<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-					</f:entry>
-					<f:entry title="${%Name}">
-						<f:textbox name="config.name" value="${config.name}" />
-					</f:entry>
-					<f:entry title="${%Comment}">
-						<f:textbox name="config.comment" value="${config.comment}" />
-					</f:entry>
+
+					<j:set var="descriptor" value="${config.descriptor}"/>
+					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+
 					<f:entry title="${%Content}">
 						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
 					</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
@@ -36,9 +36,9 @@ div.credentialssection {
 	   		<p>
 	   		 ${%description}
 	   		</p>
-	   		
-            <input type="hidden" name="config.id" value="${config.id}" />
-            
+            <f:entry title="${%ID}" >
+                <f:textbox readonly="readonly" name="config.id" value="${config.id}" />
+            </f:entry>
             <f:entry title="${%Name}">
                 <f:textbox name="config.name" value="${config.name}" />
             </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
@@ -36,15 +36,7 @@ div.credentialssection {
 	   		<p>
 	   		 ${%description}
 	   		</p>
-            <f:entry title="${%ID}" >
-                <f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-            </f:entry>
-            <f:entry title="${%Name}">
-                <f:textbox name="config.name" value="${config.name}" />
-            </f:entry>
-            <f:entry title="${%Comment}">
-                <f:textbox name="config.comment" value="${config.comment}" />
-            </f:entry>
+            <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
 
             <f:entry title="${%Replace All}" field="isReplaceAll">
                 <f:checkbox default="true" value="${config.isReplaceAll}"/>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/edit-config.jelly
@@ -36,9 +36,9 @@ div.credentialssection {
 	   		<p>
 	   		 ${%description}
 	   		</p>
-	   		
-            <input type="hidden" name="config.id" value="${config.id}" />
-            
+            <f:entry title="${%ID}" >
+                <f:textbox readonly="readonly" name="config.id" value="${config.id}" />
+            </f:entry>
             <f:entry title="${%Name}">
                 <f:textbox name="config.name" value="${config.name}" />
             </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
+import com.gargoylesoftware.htmlunit.html.*;
 import hudson.Launcher;
 import hudson.maven.MavenModuleSet;
 import hudson.model.BuildListener;
@@ -13,9 +14,11 @@ import hudson.tasks.Builder;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 import javax.inject.Inject;
 
+import org.hamcrest.Matchers;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFilesManagement;
@@ -29,11 +32,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import com.gargoylesoftware.htmlunit.html.DomNodeList;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlOption;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 public class ConfigFileBuildWrapperTest {
 
@@ -60,7 +58,7 @@ public class ConfigFileBuildWrapperTest {
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize"); // -s ${MVN_SETTING}
 
-        final Config settings = createSetting(xmlProvider);
+        final Config settings = createSetting(xmlProvider, "env-var-test-1");
         final ManagedFile mSettings = new ManagedFile(settings.id, "/tmp/new_settings.xml", "MY_SETTINGS");
         ConfigFileBuildWrapper bw = new ConfigFileBuildWrapper(Collections.singletonList(mSettings));
         p.getBuildWrappersList().add(bw);
@@ -93,8 +91,8 @@ public class ConfigFileBuildWrapperTest {
         }
     }
 
-    private Config createSetting(ConfigProvider provider) {
-        Config c1 = provider.newConfig(null);
+    private Config createSetting(ConfigProvider provider, String idSuffix) {
+        Config c1 = provider.newConfig(idSuffix);
         provider.save(c1);
         return c1;
     }
@@ -105,8 +103,9 @@ public class ConfigFileBuildWrapperTest {
 
         FreeStyleProject p = j.createFreeStyleProject("someJob");
 
-        final Config activeConfig = createSetting(xmlProvider);
-        final Config secondConfig = createSetting(xmlProvider);
+        final Config activeConfig = createSetting(xmlProvider, "active-config-1");
+        final Config secondConfig = createSetting(xmlProvider, "inactive-config-2");
+        final Config thirdConfig = createSetting(xmlProvider, null);
         final ManagedFile mSettings = new ManagedFile(activeConfig.id, "/tmp/new_settings.xml", "MY_SETTINGS");
         ConfigFileBuildWrapper bw = new ConfigFileBuildWrapper(Collections.singletonList(mSettings));
         p.getBuildWrappersList().add(bw);
@@ -114,20 +113,25 @@ public class ConfigFileBuildWrapperTest {
         final WebClient client = j.createWebClient();
         final HtmlPage page = client.goTo("job/someJob/configure");
 
-        final DomNodeList<HtmlElement> option = page.getElementsByTagName("option");
+        final List<HtmlElement> selectElts = page.getElementsByName("fileId");
+        Assert.assertThat("Only one config file drop down list is displayed", selectElts.size(), Matchers.equalTo(1));
+        HtmlSelect select = (HtmlSelect) selectElts.get(0);
         boolean foundActive = false;
         boolean foundSecond = false;
-        for (HtmlElement htmlElement : option) {
-            final HtmlOption htmlOption = (HtmlOption) htmlElement;
+
+        System.err.println("BEGIN Evaluate options against activeConfig: " + activeConfig + ", secondConfig: " + secondConfig);
+        for (HtmlOption htmlOption : select.getOptions()) {
+            System.err.println("Evaluate option value=" + htmlOption.getValueAttribute() + ", text=" + htmlOption.getText() + ", selected=" + htmlOption.isSelected());
             if (htmlOption.getValueAttribute().equals(activeConfig.id)) {
-                Assert.assertTrue("correct config is not selected", htmlOption.isSelected());
+                Assert.assertTrue("correct config ('" + htmlOption.getValueAttribute() + "') is not selected", htmlOption.isSelected());
                 foundActive = true;
             }
             if (htmlOption.getValueAttribute().equals(secondConfig.id)) {
-                Assert.assertFalse("wrong config is selected", htmlOption.isSelected());
+                Assert.assertFalse("wrong config ('" + htmlOption.getValueAttribute() + "') is selected", htmlOption.isSelected());
                 foundSecond = true;
             }
         }
+        System.err.println("END Evaluate options");
         Assert.assertTrue("configured active setting was not available as option", foundActive);
         Assert.assertTrue("configured second setting was not available as option", foundSecond);
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
@@ -94,7 +94,7 @@ public class ConfigFileBuildWrapperTest {
     }
 
     private Config createSetting(ConfigProvider provider) {
-        Config c1 = provider.newConfig();
+        Config c1 = provider.newConfig(null);
         provider.save(c1);
         return c1;
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -122,7 +122,7 @@ public class MvnSettingsCredentialsTest {
         List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
         mappings.add(mapping);
 
-        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(null);
+        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(String.valueOf(System.currentTimeMillis()));
         MavenSettingsConfig c2 = new MavenSettingsConfig(c1.id + "dummy", c1.name, c1.comment, c1.content, MavenSettingsConfig.isReplaceAllDefault, mappings);
         provider.save(c2);
         return c2;
@@ -137,7 +137,7 @@ public class MvnSettingsCredentialsTest {
         List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
         mappings.add(mapping);
 
-        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(null);
+        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(String.valueOf(System.currentTimeMillis()));
         GlobalMavenSettingsConfig c2 = new GlobalMavenSettingsConfig(c1.id + "dummy2", c1.name, c1.comment, c1.content,  GlobalMavenSettingsConfig.isReplaceAllDefault, mappings);
         provider.save(c2);
         return c2;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -122,7 +122,7 @@ public class MvnSettingsCredentialsTest {
         List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
         mappings.add(mapping);
 
-        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig();
+        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(null);
         MavenSettingsConfig c2 = new MavenSettingsConfig(c1.id + "dummy", c1.name, c1.comment, c1.content, MavenSettingsConfig.isReplaceAllDefault, mappings);
         provider.save(c2);
         return c2;
@@ -137,7 +137,7 @@ public class MvnSettingsCredentialsTest {
         List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
         mappings.add(mapping);
 
-        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig();
+        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(null);
         GlobalMavenSettingsConfig c2 = new GlobalMavenSettingsConfig(c1.id + "dummy2", c1.name, c1.comment, c1.content,  GlobalMavenSettingsConfig.isReplaceAllDefault, mappings);
         provider.save(c2);
         return c2;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
@@ -70,7 +70,7 @@ public class MvnSettingsProviderTest {
     }
 
     private Config createSetting(ConfigProvider provider) {
-        Config c1 = provider.newConfig();
+        Config c1 = provider.newConfig(null);
         provider.save(c1);
         return c1;
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
@@ -70,7 +70,7 @@ public class MvnSettingsProviderTest {
     }
 
     private Config createSetting(ConfigProvider provider) {
-        Config c1 = provider.newConfig(null);
+        Config c1 = provider.newConfig(String.valueOf(System.currentTimeMillis()));
         provider.save(c1);
         return c1;
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -79,14 +79,14 @@ public class SettingsEnvVarTest {
 
     private MavenSettingsConfig createSettings(MavenSettingsConfigProvider provider) throws Exception {
 
-        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(null);
+        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(String.valueOf(System.currentTimeMillis()));
         provider.save(c1);
         return c1;
     }
 
     private GlobalMavenSettingsConfig createGlobalSettings(GlobalMavenSettingsConfigProvider provider) throws Exception {
 
-        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(null);
+        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(String.valueOf(System.currentTimeMillis()));
         provider.save(c1);
         return c1;
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -79,14 +79,14 @@ public class SettingsEnvVarTest {
 
     private MavenSettingsConfig createSettings(MavenSettingsConfigProvider provider) throws Exception {
 
-        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig();
+        MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig(null);
         provider.save(c1);
         return c1;
     }
 
     private GlobalMavenSettingsConfig createGlobalSettings(GlobalMavenSettingsConfigProvider provider) throws Exception {
 
-        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig();
+        GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig(null);
         provider.save(c1);
         return c1;
     }


### PR DESCRIPTION
Predictable configuration file identifier is key to use the config-file-provider-plugin in Jenkins workflow and even more in `Jenkinsfile`.

The config-file-provider-plugin currently only supports random identifiers (suffixed by `System.currentTimeMillis()`) such as `org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1445959093236` and the usage in Jenkins workflow is cumbersome: 

```groovy
wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[
   fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1445959093236', 
   targetLocation: './m2-settings.xml']]]) {

    // some block
}
```

Random/unpredictable identifier are even more cumbersome with `Jenkinsfile` as the `Jenkinsfile` is stored with the source code and thus should be executed on any Jenkins server.

This Pull Requests is inspired by the user defined ids introduced for the credentials. The key difference is that the config-file-provider-plugin require the ID to be prefixed by the `ConfigProvider.getId()` so we let user specify the suffix of the ID. If no suffix is defined, then the current pattern based on `System.currentTimeMillis()` is used.

Sample user defined Config File ID: `org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.myMavenSettings`

Screenshot:

![Configuration File Provider Plugin - Optional ID Suffix](http://snag.gy/lQSAt.jpg)
