### PR TITLE
Fix FindBugs "Non-transient non-serializable instance field in serializable class (SE_BAD_FIELD)"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.configfiles.maven.security;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +25,7 @@ import hudson.security.AccessControlled;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
-public class ServerCredentialMapping extends AbstractDescribableImpl<ServerCredentialMapping> {
+public class ServerCredentialMapping extends AbstractDescribableImpl<ServerCredentialMapping> implements Serializable {
 
     private final String serverId;
     private final String credentialsId;


### PR DESCRIPTION
Fix FindBugs "Non-transient non-serializable instance field in serializable class (SE_BAD_FIELD)" making `ServerCredentialMapping` implement Serializable.