### PR TITLE
WIP [JENKINS-40665, JENKINS-39407] Support Maven Settings Provider and Maven Global Settings Provider for pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.17</version>
+        <version>2.19</version>
     </parent>
 
     <artifactId>config-file-provider</artifactId>
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.38-SNAPSHOT</jenkins.version>
         <java.level>7</java.level>
         <findbugs.failOnError>true</findbugs.failOnError>
     </properties>
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.12.1</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
@@ -85,18 +85,18 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.3</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- FilePathUtils -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.8</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -108,51 +108,57 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.1</version>
+            <version>2.9</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3.5</version>
+            <version>2.6.1</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- conflicts with used httpclient -->
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -163,8 +169,14 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.11</version>
+            <version>1.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>2.16-SNAPSHOT</version>
+    <version>2.15.1</version>
 
     <packaging>hpi</packaging>
 
@@ -19,7 +19,7 @@
         <connection>scm:git:git://github.com/jenkinsci/config-file-provider-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/config-file-provider-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
-        <tag>HEAD</tag>
+        <tag>config-file-provider-2.15.1</tag>
     </scm>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>2.15</version>
+    <version>2.16-SNAPSHOT</version>
 
     <packaging>hpi</packaging>
 
@@ -19,7 +19,7 @@
         <connection>scm:git:git://github.com/jenkinsci/config-file-provider-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/config-file-provider-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
-        <tag>config-file-provider-2.15</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>2.14.3-SNAPSHOT</version>
+    <version>2.15</version>
 
     <packaging>hpi</packaging>
 
@@ -19,7 +19,7 @@
         <connection>scm:git:git://github.com/jenkinsci/config-file-provider-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/config-file-provider-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
-        <tag>HEAD</tag>
+        <tag>config-file-provider-2.15</tag>
     </scm>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.9</version>
+            <version>2.10</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,14 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.3</version>
             </plugin>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <compatibleSinceVersion>2.15</compatibleSinceVersion>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>2.15.1</version>
+    <version>2.15.2-SNAPSHOT</version>
 
     <packaging>hpi</packaging>
 
@@ -19,7 +19,7 @@
         <connection>scm:git:git://github.com/jenkinsci/config-file-provider-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/config-file-provider-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
-        <tag>config-file-provider-2.15.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <repository>

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -23,10 +23,8 @@
  */
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
-import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
@@ -36,7 +34,6 @@ import hudson.tasks.BuildWrapperDescriptor;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -46,8 +43,6 @@ import jenkins.tasks.SimpleBuildWrapper;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.lib.configprovider.ConfigProvider;
-import org.jenkinsci.lib.configprovider.model.Config;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
@@ -74,6 +69,7 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
             if (noTargetGiven) {
                 tempFiles.add(entry.getValue().getRemote());
             }
+            listener.getLogger().println("Provide configuration file " + mf.fileId + " at " + fp.getRemote());
         }
         if (!tempFiles.isEmpty()) {
             context.setDisposer(new TempFileCleaner(tempFiles));

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -98,7 +98,7 @@ public class ManagedFileUtil {
 
                 String expandedTargetLocation = managedFile.targetLocation;
                 try {
-                    expandedTargetLocation = build instanceof AbstractBuild ? TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, managedFile.targetLocation) : managedFile.targetLocation;
+                    expandedTargetLocation = TokenMacro.expandAll(build, workspace, listener, managedFile.targetLocation);
                 } catch (MacroEvaluationException e) {
                     listener.getLogger().println("[ERROR] failed to expand variables in target location '" + managedFile.targetLocation + "' : " + e.getMessage());
                     expandedTargetLocation = managedFile.targetLocation;
@@ -119,7 +119,7 @@ public class ManagedFileUtil {
 
             if (managedFile.getReplaceTokens()) {
                 try {
-                    fileContent = build instanceof AbstractBuild ? TokenMacro.expandAll((AbstractBuild<?, ?>) build, listener, fileContent) : fileContent;
+                    fileContent = TokenMacro.expandAll(build, workspace, listener, fileContent);
                 } catch (MacroEvaluationException e) {
                     listener.getLogger().println("[ERROR] failed to expand variables in content of " + configFile.name + " - " + e.getMessage());
                 }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -1,22 +1,19 @@
 package org.jenkinsci.plugins.configfiles.maven.job;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.model.AbstractBuild;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import hudson.slaves.WorkspaceList;
 import hudson.util.ListBoxModel;
 import jenkins.mvn.SettingsProvider;
 import jenkins.mvn.SettingsProviderDescriptor;
-
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
@@ -29,7 +26,15 @@ import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * This provider delivers the settings.xml to the job during job/project execution. <br>
@@ -62,6 +67,70 @@ public class MvnSettingsProvider extends SettingsProvider {
     public void setSettingsConfigId(String settingsConfigId) {
         this.settingsConfigId = settingsConfigId;
     }
+
+    @Override
+    @CheckForNull
+    public FilePath supplySettings(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull TaskListener listener) {
+        if (StringUtils.isBlank(settingsConfigId)) {
+            return null;
+        }
+
+        Config c = ConfigFiles.getByIdOrNull((Item) run, settingsConfigId);
+
+
+        PrintStream console = listener.getLogger();
+        if (c == null) {
+            listener.error("Maven settings.xml with id '" + settingsConfigId + "' not found");
+            return null;
+        }
+        if (StringUtils.isBlank(c.content)) {
+            console.format("Ignore empty maven settings.xml with id " + settingsConfigId);
+            return null;
+        }
+
+        MavenSettingsConfig config;
+        if (c instanceof MavenSettingsConfig) {
+            config = (MavenSettingsConfig) c;
+        } else {
+            config = new MavenSettingsConfig(c.id, c.name, c.comment, c.content, MavenSettingsConfig.isReplaceAllDefault, null);
+        }
+
+
+        try {
+            FilePath  tmpDir = WorkspaceList.tempDir(workspace).createTempDir("config-file-provider","maven");
+
+            String fileContent = config.content;
+
+            final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
+            final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(run, serverCredentialMappings);
+            final Boolean isReplaceAll = config.getIsReplaceAll();
+
+            if (resolvedCredentials.isEmpty()) {
+
+            } else {
+                // temporary credentials files (ssh pem files...)
+                List<String> tmpCredentialsFiles = new ArrayList<>();
+                console.print("Inject in Maven settings.xml credentials (replaceAll: " + config.isReplaceAll + ") for: " + Joiner.on(",").join(resolvedCredentials.keySet()));
+                fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, tmpDir, tmpCredentialsFiles);
+                for (String tempFile : tmpCredentialsFiles) {
+                    run.addAction(new CleanTempFilesAction(tempFile));
+                }
+            }
+
+            final FilePath mavenSettingsFile = tmpDir.child("settings.xml");
+            mavenSettingsFile.copyFrom(org.apache.commons.io.IOUtils.toInputStream(fileContent, Charsets.UTF_8));
+
+            LOGGER.log(Level.FINE, "Create {0} from {1}", new Object[]{mavenSettingsFile, config.id});
+
+            // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
+            // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
+            run.addAction(new CleanTempFilesAction(mavenSettingsFile.getRemote()));
+            return mavenSettingsFile;
+        } catch (Exception e) {
+            throw new IllegalStateException("the settings.xml could not be supplied for the current build: " + e.getMessage(), e);
+        }
+    }
+
 
     @Override
     public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -26,6 +26,7 @@ import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,13 +71,12 @@ public class MvnSettingsProvider extends SettingsProvider {
 
     @Override
     @CheckForNull
-    public FilePath supplySettings(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull TaskListener listener) {
+    public FilePath supplySettings(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException {
         if (StringUtils.isBlank(settingsConfigId)) {
             return null;
         }
 
-        Config c = ConfigFiles.getByIdOrNull((Item) run, settingsConfigId);
-
+        Config c = ConfigFiles.getByIdOrNull(run, settingsConfigId);
 
         PrintStream console = listener.getLogger();
         if (c == null) {
@@ -95,104 +95,48 @@ public class MvnSettingsProvider extends SettingsProvider {
             config = new MavenSettingsConfig(c.id, c.name, c.comment, c.content, MavenSettingsConfig.isReplaceAllDefault, null);
         }
 
+        FilePath workspaceTmpDir = WorkspaceList.tempDir(workspace);
+        workspaceTmpDir.mkdirs();
 
-        try {
-            FilePath  tmpDir = WorkspaceList.tempDir(workspace).createTempDir("config-file-provider","maven");
+        String fileContent = config.content;
 
-            String fileContent = config.content;
+        final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
+        final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(run, serverCredentialMappings);
+        final Boolean isReplaceAll = config.getIsReplaceAll();
 
-            final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
-            final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(run, serverCredentialMappings);
-            final Boolean isReplaceAll = config.getIsReplaceAll();
-
-            if (resolvedCredentials.isEmpty()) {
-
-            } else {
-                // temporary credentials files (ssh pem files...)
-                List<String> tmpCredentialsFiles = new ArrayList<>();
-                console.print("Inject in Maven settings.xml credentials (replaceAll: " + config.isReplaceAll + ") for: " + Joiner.on(",").join(resolvedCredentials.keySet()));
-                fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, tmpDir, tmpCredentialsFiles);
-                for (String tempFile : tmpCredentialsFiles) {
-                    run.addAction(new CleanTempFilesAction(tempFile));
-                }
+        if (!resolvedCredentials.isEmpty()) {
+            // temporary credentials files (ssh pem files...)
+            List<String> tmpCredentialsFiles = new ArrayList<>();
+            console.println("Inject in Maven settings.xml credentials (replaceAll: " + config.isReplaceAll + ") for: " + Joiner.on(",").join(resolvedCredentials.keySet()));
+            try {
+                fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, workspaceTmpDir, tmpCredentialsFiles);
+            } catch (IOException e) {
+                throw new IOException("Exception injecting credentials for maven settings file '" + config.id + "' during '" + run + "'", e);
+            } catch (InterruptedException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException("Exception injecting credentials for maven settings file '" + config.id + "' during '" + run + "'", e);
             }
-
-            final FilePath mavenSettingsFile = tmpDir.child("settings.xml");
-            mavenSettingsFile.copyFrom(org.apache.commons.io.IOUtils.toInputStream(fileContent, Charsets.UTF_8));
-
-            LOGGER.log(Level.FINE, "Create {0} from {1}", new Object[]{mavenSettingsFile, config.id});
-
-            // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
-            // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
-            run.addAction(new CleanTempFilesAction(mavenSettingsFile.getRemote()));
-            return mavenSettingsFile;
-        } catch (Exception e) {
-            throw new IllegalStateException("the settings.xml could not be supplied for the current build: " + e.getMessage(), e);
-        }
-    }
-
-
-    @Override
-    public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (StringUtils.isNotBlank(settingsConfigId)) {
-
-            Config c = null;
-            if (build instanceof Item) {
-                c = ConfigFiles.getByIdOrNull((Item) build, settingsConfigId);
-            } else if (build instanceof ItemGroup) {
-                c = ConfigFiles.getByIdOrNull((ItemGroup) build, settingsConfigId);
-            } else if (build.getParent() instanceof ItemGroup) {
-                c = ConfigFiles.getByIdOrNull((ItemGroup) build.getParent(), settingsConfigId);
-            }
-
-            if (c == null) {
-                listener.getLogger().println("ERROR: your Apache Maven build is setup to use a config with id " + settingsConfigId + " but can not find the config");
-            } else {
-
-                MavenSettingsConfig config;
-                if (c instanceof MavenSettingsConfig) {
-                    config = (MavenSettingsConfig) c;
-                } else {
-                    config = new MavenSettingsConfig(c.id, c.name, c.comment, c.content, MavenSettingsConfig.isReplaceAllDefault, null);
-                }
-
-                listener.getLogger().println("using settings config with name " + config.name);
-                listener.getLogger().println("Replacing all maven server entries not found in credentials list is " + config.getIsReplaceAll());
-                if (StringUtils.isNotBlank(config.content)) {
-                    FilePath workDir = ManagedFileUtil.tempDir(build.getWorkspace());
-
-                    try {
-
-                        String fileContent = config.content;
-
-                        final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
-                        final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, serverCredentialMappings);
-                        final Boolean isReplaceAll = config.getIsReplaceAll();
-
-                        if (!resolvedCredentials.isEmpty()) {
-                            List<String> tempFiles = new ArrayList<String>();
-                            fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, workDir, tempFiles);
-                            for (String tempFile : tempFiles) {
-                                build.addAction(new CleanTempFilesAction(tempFile));
-                            }
-                        }
-
-                        final FilePath f = build.getWorkspace().createTextTempFile("settings", ".xml", fileContent, false);
-                        LOGGER.log(Level.FINE, "Create {0}", new Object[]{f});
-                        build.getEnvironments().add(new SimpleEnvironment("MVN_SETTINGS", f.getRemote()));
-
-                        // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
-                        // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
-                        build.addAction(new CleanTempFilesAction(f.getRemote()));
-                        return f;
-                    } catch (Exception e) {
-                        throw new IllegalStateException("the settings.xml could not be supplied for the current build: " + e.getMessage(), e);
-                    }
-                }
+            for (String tmpCredentialsFile : tmpCredentialsFiles) {
+                run.addAction(new CleanTempFilesAction(tmpCredentialsFile));
             }
         }
 
-        return null;
+        final FilePath mavenSettingsFile = workspaceTmpDir.createTempFile ("maven-","-settings.xml");
+        mavenSettingsFile.copyFrom(org.apache.commons.io.IOUtils.toInputStream(fileContent, Charsets.UTF_8));
+
+        LOGGER.log(Level.FINE, "Create {0} from {1}", new Object[]{mavenSettingsFile, config.id});
+
+        // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
+        // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
+        run.addAction(new CleanTempFilesAction(mavenSettingsFile.getRemote()));
+
+        if (run instanceof AbstractBuild) {
+            AbstractBuild build = (AbstractBuild) run;
+            build.getEnvironments().add(new SimpleEnvironment("MVN_SETTINGS", mavenSettingsFile.getRemote()));
+        }
+
+        return mavenSettingsFile;
     }
 
     @Extension(ordinal = 10)

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/security/CredentialsHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/security/CredentialsHelperTest.java
@@ -1,33 +1,37 @@
 
 package org.jenkinsci.plugins.configfiles.maven.security;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
 public class CredentialsHelperTest {
 
     final static String PWD     = "MY_NEW_PWD";
     final static String PWD_2   = "{COQLCE6DU6GtcS5P=}";
+    final static int SERVER_COUNT = 5;
 
     @Rule
     public JenkinsRule  jenkins = new JenkinsRule();
@@ -83,7 +87,7 @@ public class CredentialsHelperTest {
         XPath xpath = XPathFactory.newInstance().newXPath();
         NodeList nodes = (NodeList) xpath.evaluate("/settings/servers/server", doc, XPathConstants.NODESET);
         // the 'settings_test.xml' actually contains 4 server tags, but we remove all and only inject the ones managed by the plugin
-        Assert.assertEquals("there is not the same number of server tags anymore in the settings.xml", 4, nodes.getLength());
+        Assert.assertEquals("there is not the same number of server tags anymore in the settings.xml", SERVER_COUNT, nodes.getLength());
 
     }
 
@@ -112,4 +116,49 @@ public class CredentialsHelperTest {
         Assert.assertEquals("no changes should have been made to the settings", settingsContent, replacedContent);
 
     }
+
+    @Issue("JENKINS-39991")
+    @Test
+    public void testIfServerElementAreKeeptWhenMatchCredentialsWhenReplaceFalse() throws Exception {
+        testIfServerElementAreKeeptWhenMatchCredentials(false);
+
+    }
+
+    @Issue("JENKINS-39991")
+    @Test
+    public void testIfServerElementAreKeeptWhenMatchCredentialsWhenReplaceTrue() throws Exception {
+        testIfServerElementAreKeeptWhenMatchCredentials(true);
+    }
+
+    private void testIfServerElementAreKeeptWhenMatchCredentials(boolean replaceAll) throws Exception {
+        final String serverId = "jenkins-39991";
+
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
+        serverId2Credentials.put(serverId, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
+
+        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        List<String> tempFiles = new ArrayList<String>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, replaceAll, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+
+        // read original server settings
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(settingsContent)));
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        Node server = (Node) xpath.evaluate("/settings/servers/server[id='" + serverId + "']", doc, XPathConstants.NODE);
+        String filePermissions = xpath.evaluate("filePermissions", server);
+        String directoryPermissions = xpath.evaluate("directoryPermissions", server);
+        String configuration = xpath.evaluate("configuration", server);
+
+        // ensure it is still a valid XML document
+        doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(replacedContent)));
+        // locate the node(s)
+        xpath = XPathFactory.newInstance().newXPath();
+
+        server = (Node) xpath.evaluate("/settings/servers/server[id='" + serverId + "']", doc, XPathConstants.NODE);
+        Assert.assertEquals("password is not at the correct location", PWD, xpath.evaluate("password", server));
+        Assert.assertEquals("username is not set correct", "peter", xpath.evaluate("username", server));
+        Assert.assertEquals("filePermissions is not set correct", filePermissions, xpath.evaluate("filePermissions", server));
+        Assert.assertEquals("directoryPermissions is not set correct", directoryPermissions, xpath.evaluate("directoryPermissions", server));
+        Assert.assertEquals("configuration is not set correct", configuration, xpath.evaluate("configuration", server));
+    }
+
 }

--- a/src/test/resources/settings_test.xml
+++ b/src/test/resources/settings_test.xml
@@ -91,12 +91,22 @@
             <username>dummy1</username>
             <password>XXX</password>
         </server>        
-		<server>
-		    <id>my-passphraseserver</id>
-			<passphrase>AAAAAAAAA</passphrase>
-			<privateKey>OldKey</privateKey>
-		</server>
-        
+        <server>
+            <id>my-passphraseserver</id>
+            <passphrase>AAAAAAAAA</passphrase>
+            <privateKey>OldKey</privateKey>
+        </server>
+        <server>
+            <id>jenkins-39991</id>
+            <passphrase>secret</passphrase>
+            <privateKey>ssh-rsa qwerty==</privateKey>
+            <filePermissions>644</filePermissions>
+            <directoryPermissions>744</directoryPermissions>
+            <configuration>
+                <interactive>false</interactive>
+            </configuration>
+        </server>
+
     </servers>
 
     <!-- mirrors | This is a list of mirrors to be used in downloading artifacts 


### PR DESCRIPTION
Support Maven Settings Provider and Maven Global Settings Provider for pipeline and make it work with `withMaven(){}`

See
* [JENKINS-40665 Maven SettingsProvider and GlobalSettingsProvider should support Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40665)
* [JENKINS-39407 Use system default Maven, Maven Settings if not specified](https://issues.jenkins-ci.org/browse/JENKINS-39407)
* PR https://github.com/jenkinsci/jenkins/pull/2678
* PR https://github.com/jenkinsci/pipeline-maven-plugin/pull/14
* PR https://github.com/jenkinsci/config-file-provider-plugin/pull/24
