### PR TITLE
WIP [JENKINS-40665, JENKINS-39407] Support Maven Settings Provider and Maven Global Settings Provider for pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.17</version>
+        <version>2.19</version>
     </parent>
 
     <artifactId>config-file-provider</artifactId>
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.38-SNAPSHOT</jenkins.version>
         <java.level>7</java.level>
         <findbugs.failOnError>true</findbugs.failOnError>
     </properties>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
@@ -85,18 +85,18 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.3</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- FilePathUtils -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.8</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -108,51 +108,57 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.1</version>
+            <version>2.10</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3.5</version>
+            <version>2.6.1</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- conflicts with used httpclient -->
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>2.13</version>
+            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -163,8 +169,14 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>1.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.11</version>
+            <version>1.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -74,6 +74,7 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
             if (noTargetGiven) {
                 tempFiles.add(entry.getValue().getRemote());
             }
+            listener.getLogger().println("Provide configuration file " + mf.fileId + " at " + fp.getRemote());
         }
         if (!tempFiles.isEmpty()) {
             context.setDisposer(new TempFileCleaner(tempFiles));

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -1,34 +1,43 @@
 package org.jenkinsci.plugins.configfiles.maven.job;
 
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 
+import java.io.IOException;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.slaves.WorkspaceList;
 import hudson.util.ListBoxModel;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.GlobalSettingsProviderDescriptor;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
-import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFileUtil;
 import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
+import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+
 
 /**
  * This provider delivers the global settings.xml to the job during job/project execution. <br>
@@ -63,65 +72,74 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
     }
 
     @Override
-    public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (StringUtils.isNotBlank(settingsConfigId)) {
+    @CheckForNull
+    public FilePath supplySettings(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException{
+        if (StringUtils.isBlank(settingsConfigId)) {
+            return null;
+        }
 
-            Config c = null;
-            if (build instanceof Item) {
-                c = ConfigFiles.getByIdOrNull((Item) build, settingsConfigId);
-            } else if (build instanceof ItemGroup) {
-                c = ConfigFiles.getByIdOrNull((ItemGroup) build, settingsConfigId);
-            } else if (build.getParent() instanceof ItemGroup) {
-                c = ConfigFiles.getByIdOrNull((ItemGroup) build.getParent(), settingsConfigId);
+        Config c = ConfigFiles.getByIdOrNull(run, settingsConfigId);
+
+        PrintStream console = listener.getLogger();
+        if (c == null) {
+            listener.error("Maven global settings.xml with id '" + settingsConfigId + "' not found");
+            return null;
+        }
+        if (StringUtils.isBlank(c.content)) {
+            console.format("Ignore empty maven global settings.xml with id " + settingsConfigId);
+            return null;
+        }
+
+        GlobalMavenSettingsConfig config;
+        if (c instanceof GlobalMavenSettingsConfig) {
+            config = (GlobalMavenSettingsConfig) c;
+        } else {
+            config = new GlobalMavenSettingsConfig(c.id, c.name, c.comment, c.content, GlobalMavenSettingsConfig.isReplaceAllDefault, null);
+        }
+
+        FilePath workspaceTmpDir = WorkspaceList.tempDir(workspace);
+        workspaceTmpDir.mkdirs();
+
+        String fileContent = config.content;
+
+        final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();
+        final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(run, serverCredentialMappings);
+        final Boolean isReplaceAll = config.getIsReplaceAll();
+
+        if (!resolvedCredentials.isEmpty()) {
+            // temporary credentials files (ssh pem files...)
+            List<String> tmpCredentialsFiles = new ArrayList<>();
+            console.println("Inject in Maven global settings.xml credentials (replaceAll: " + config.isReplaceAll + ") for: " + Joiner.on(",").join(resolvedCredentials.keySet()));
+            try {
+                fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, workspaceTmpDir, tmpCredentialsFiles);
+            } catch (IOException e) {
+                throw new IOException("Exception injecting credentials for maven global settings file '" + config.id + "' during '" + run + "'", e);
+            } catch (InterruptedException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException("Exception injecting credentials for maven global settings file '" + config.id + "' during '" + run + "'", e);
             }
-
-
-            if (c == null) {
-                listener.getLogger().println("ERROR: your Apache Maven build is setup to use a config with id " + settingsConfigId + " but can not find the config");
-            } else {
-
-                GlobalMavenSettingsConfig config;
-                if (c instanceof GlobalMavenSettingsConfig) {
-                    config = (GlobalMavenSettingsConfig) c;
-                } else {
-                    config = new GlobalMavenSettingsConfig(c.id, c.name, c.comment, c.content, GlobalMavenSettingsConfig.isReplaceAllDefault, null);
-                }
-
-                listener.getLogger().println("using global settings config with name " + config.name);
-                listener.getLogger().println("Replacing all maven server entries not found in credentials list is " + config.getIsReplaceAll());
-                if (StringUtils.isNotBlank(config.content)) {
-                    try {
-
-                        FilePath workDir = ManagedFileUtil.tempDir(build.getWorkspace());
-                        String fileContent = config.content;
-
-                        final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, config.getServerCredentialMappings());
-                        final Boolean isReplaceAll = config.getIsReplaceAll();
-
-                        if (!resolvedCredentials.isEmpty()) {
-                            List<String> tempFiles = new ArrayList<String>();
-                            fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, workDir, tempFiles);
-                            for (String tempFile : tempFiles) {
-                                build.addAction(new CleanTempFilesAction(tempFile));
-                            }
-                        }
-
-                        FilePath configurationFile = build.getWorkspace().createTextTempFile("global-settings", ".xml", fileContent, false);
-                        LOGGER.log(Level.FINE, "Create {0}", new Object[]{configurationFile});
-                        build.getEnvironments().add(new SimpleEnvironment("MVN_GLOBALSETTINGS", configurationFile.getRemote()));
-
-                        // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
-                        // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
-                        build.addAction(new CleanTempFilesAction(configurationFile.getRemote()));
-                        return configurationFile;
-                    } catch (Exception e) {
-                        throw new IllegalStateException("the global settings.xml could not be supplied for the current build: " + e.getMessage());
-                    }
-                }
+            for (String tmpCredentialsFile : tmpCredentialsFiles) {
+                run.addAction(new CleanTempFilesAction(tmpCredentialsFile));
             }
         }
 
-        return null;
+        final FilePath mavenGlobalSettingsFile = workspaceTmpDir.createTempFile("maven-global-", "-settings.xml");
+        mavenGlobalSettingsFile.copyFrom(org.apache.commons.io.IOUtils.toInputStream(fileContent, Charsets.UTF_8));
+
+        LOGGER.log(Level.FINE, "Create {0} from {1}", new Object[]{mavenGlobalSettingsFile, config.id});
+
+        // Temporarily attach info about the files to be deleted to the build - this action gets removed from the build again by
+        // 'org.jenkinsci.plugins.configfiles.common.CleanTempFilesRunListener'
+        run.addAction(new CleanTempFilesAction(mavenGlobalSettingsFile.getRemote()));
+
+        if (run instanceof AbstractBuild) {
+            AbstractBuild build = (AbstractBuild) run;
+            build.getEnvironments().add(new SimpleEnvironment("MVN_GLOBALSETTINGS", mavenGlobalSettingsFile.getRemote()));
+        }
+
+        return mavenGlobalSettingsFile;
+
     }
 
     @Extension(ordinal = 10)


### PR DESCRIPTION
Support Maven Settings Provider and Maven Global Settings Provider for pipeline and make it work with `withMaven(){}`

See
* [JENKINS-40665 Maven SettingsProvider and GlobalSettingsProvider should support Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40665)
* [JENKINS-39407 Use system default Maven, Maven Settings if not specified](https://issues.jenkins-ci.org/browse/JENKINS-39407)
* PR https://github.com/jenkinsci/jenkins/pull/2818
* PR https://github.com/jenkinsci/pipeline-maven-plugin/pull/31
* PR https://github.com/jenkinsci/config-file-provider-plugin/pull/25