### PR TITLE
Avoid a lot of AbstractMethodError at jenkins startup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
@@ -108,4 +108,9 @@ public class GlobalConfigFiles extends Descriptor<GlobalConfigFiles> implements 
         configs.remove(c);
         save();
     }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.display_name();
+    }
 }


### PR DESCRIPTION
When jenkins start it gathers and sorts extension point by ordinal property.
In case of same ordinal value it sort using displayName.
This class does not implement getDisplayName, so during sort each time this extension is compared with other an AbstractMethodError is raised, ExtensionComponent logs exception as warning and proceed comparing class name.

I have a lot of this on startup:
```
gen 05, 2017 12:05:58 PM hudson.ExtensionComponent compareTo
WARNING: null
java.lang.AbstractMethodError
	at hudson.ExtensionComponent.compareTo(ExtensionComponent.java:97)
	at hudson.ExtensionComponent.compareTo(ExtensionComponent.java:42)
	at java.util.ComparableTimSort.mergeHi(ComparableTimSort.java:773)
	at java.util.ComparableTimSort.mergeAt(ComparableTimSort.java:453)
	at java.util.ComparableTimSort.mergeForceCollapse(ComparableTimSort.java:392)
	at java.util.ComparableTimSort.sort(ComparableTimSort.java:191)
	at java.util.ComparableTimSort.sort(ComparableTimSort.java:146)
	at java.util.Arrays.sort(Arrays.java:472)
	at java.util.Collections.sort(Collections.java:155)
	at hudson.ExtensionList.sort(ExtensionList.java:369)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:289)
	at hudson.ExtensionList.iterator(ExtensionList.java:156)
	at hudson.diagnosis.NullIdDescriptorMonitor.verify(NullIdDescriptorMonitor.java:68)
	at hudson.diagnosis.NullIdDescriptorMonitor.verifyId(NullIdDescriptorMonitor.java:89)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:106)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:176)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:905)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```