### PR TITLE
Partialy restore binary compatibility with 2.13 and older releases

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -34,6 +34,7 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 
 import java.util.Collection;
 
@@ -128,4 +129,46 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
         return true;
     }
 
+
+    /**
+     * @deprecated Use <tt>GlobalConfigFiles.get().getConfigs()</tt> instead.
+     */
+    @Deprecated
+    public Collection<Config> getAllConfigs() {
+        return GlobalConfigFiles.get().getConfigs();
+    }
+
+    /**
+     * @deprecated Use <tt>GlobalConfigFiles.get().getById(String)</tt> instead.
+     */
+    @Deprecated
+    public Config getConfigById(String configId) {
+        return GlobalConfigFiles.get().getById(configId);
+    }
+
+    /**
+     * @deprecated Use <tt>GlobalConfigFiles.get().getById(String)</tt> instead.
+     */
+    @Deprecated
+    public boolean configExists(String configId) {
+        return GlobalConfigFiles.get().getById(configId) != null;
+    }
+
+    /**
+     * @deprecated Use <tt>GlobalConfigFiles.get().remove(String)</tt> instead.
+     */
+    @Deprecated
+    public void remove(String configId) {
+        GlobalConfigFiles.get().remove(configId);
+        this.save();
+    }
+
+    /**
+     * @deprecated Use <tt>GlobalConfigFiles.get().save(Config)</tt> instead.
+     */
+    @Deprecated
+    public void save(Config config) {
+        GlobalConfigFiles.get().save(config);
+        this.save();
+    }
 }

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -26,14 +26,13 @@ package org.jenkinsci.lib.configprovider;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import groovy.ui.SystemOutputInterceptor;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Descriptor;
+import hudson.model.ItemGroup;
 import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
-import org.jenkinsci.plugins.configfiles.ConfigFileStore;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 
 import java.util.Collection;
@@ -131,15 +130,15 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
 
 
     /**
-     * @deprecated Use <tt>GlobalConfigFiles.get().getConfigs()</tt> instead.
+     * @deprecated Use {@link org.jenkinsci.plugins.configfiles.ConfigFiles#getConfigsInContext(ItemGroup, Class)} instead.
      */
     @Deprecated
     public Collection<Config> getAllConfigs() {
-        return GlobalConfigFiles.get().getConfigs();
+        return GlobalConfigFiles.get().getConfigs(getClass());
     }
 
     /**
-     * @deprecated Use <tt>GlobalConfigFiles.get().getById(String)</tt> instead.
+     * @deprecated Use {@link org.jenkinsci.plugins.configfiles.ConfigFiles#getByIdOrNull} instead.
      */
     @Deprecated
     public Config getConfigById(String configId) {
@@ -147,7 +146,7 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
     }
 
     /**
-     * @deprecated Use <tt>GlobalConfigFiles.get().getById(String)</tt> instead.
+     * @deprecated Use {@link org.jenkinsci.plugins.configfiles.ConfigFiles#getByIdOrNull} instead.
      */
     @Deprecated
     public boolean configExists(String configId) {


### PR DESCRIPTION
The tests are passing for me in openstack-cloud-plugin without any modification there. I will give it a bit more manual testing with old and new c-f-p and report here. Anyway, I really believe the compatibility must be preserved here.