### PR TITLE
#refs JENKINS-12114: allow manage (CRUD) config files on folders with…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -5,6 +5,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Action;
 import hudson.model.Hudson;
+import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.FormValidation;
 import jenkins.model.TransientActionFactory;
@@ -59,6 +60,10 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
         return null;
     }
 
+    public String getPermissionGranted() {
+        return "foo";
+    }
+
     @Override
     public Map<ConfigProvider, Collection<Config>> getGroupedConfigs() {
         ConfigFileStore store = getStore();
@@ -80,8 +85,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
 
     @Override
     public HttpResponse doSaveConfig(StaplerRequest req) throws IOException, ServletException {
-        checkPermission(Hudson.ADMINISTER);
-
+        checkPermission(Job.CONFIGURE);
         try {
             JSONObject json = req.getSubmittedForm().getJSONObject("config");
             Config config = req.bindJSON(Config.class, json);
@@ -113,18 +117,15 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
 
     @Override
     public void doShow(StaplerRequest req, StaplerResponse rsp, @QueryParameter("id") String confgiId) throws IOException, ServletException {
-
         Config config = getStore().getById(confgiId);
         req.setAttribute("contentType", config.getProvider().getContentType());
         req.setAttribute("config", config);
         req.getView(this, "show.jelly").forward(req, rsp);
-
     }
 
     @Override
     public void doEditConfig(StaplerRequest req, StaplerResponse rsp, @QueryParameter("id") String confgiId) throws IOException, ServletException {
-        checkPermission(Hudson.ADMINISTER);
-
+        checkPermission(Job.CONFIGURE);
         Config config = getStore().getById(confgiId);
         req.setAttribute("contentType", config.getProvider().getContentType());
         req.setAttribute("config", config);
@@ -135,8 +136,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
 
     @Override
     public void doAddConfig(StaplerRequest req, StaplerResponse rsp, @QueryParameter("providerId") String providerId, @QueryParameter("configId") String configId) throws IOException, ServletException {
-
-        checkPermission(Hudson.ADMINISTER);
+        checkPermission(Job.CONFIGURE);
 
         FormValidation error = null;
         if (providerId == null || providerId.isEmpty()) {
@@ -147,7 +147,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
         }
         if (error != null) {
             req.setAttribute("error", error);
-            checkPermission(Hudson.ADMINISTER);
+            checkPermission(Job.CONFIGURE);
             req.setAttribute("providers", getProviders());
             req.setAttribute("configId", configId);
             req.getView(this, "selectprovider.jelly").forward(req, rsp);
@@ -174,8 +174,8 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
     }
 
     @Override
-    public void doSelectProvider(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        checkPermission(Hudson.ADMINISTER);
+    public void doSelectProvider(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {;
+            checkPermission(Job.CONFIGURE);
         req.setAttribute("providers", getProviders());
         req.setAttribute("configId", UUID.randomUUID().toString());
         req.getView(this, "selectprovider.jelly").forward(req, rsp);
@@ -183,7 +183,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
 
     @Override
     public HttpResponse doRemoveConfig(StaplerRequest res, StaplerResponse rsp, @QueryParameter("id") String configId) throws IOException {
-        checkPermission(Hudson.ADMINISTER);
+        checkPermission(Job.CONFIGURE);
 
         getStore().remove(configId);
 
@@ -218,7 +218,10 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
     }
 
     private void checkPermission(Permission permission) {
-        Hudson.getInstance().checkPermission(permission);
+//        Ancestor ancestor = req.findAncestor(Folder.class);
+//        Folder parent = (Folder) ancestor.getObject();
+
+        this.folder.checkPermission(permission);
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -60,10 +60,6 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
         return null;
     }
 
-    public String getPermissionGranted() {
-        return "foo";
-    }
-
     @Override
     public Map<ConfigProvider, Collection<Config>> getGroupedConfigs() {
         ConfigFileStore store = getStore();
@@ -218,10 +214,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract {
     }
 
     private void checkPermission(Permission permission) {
-//        Ancestor ancestor = req.findAncestor(Folder.class);
-//        Folder parent = (Folder) ancestor.getObject();
-
-        this.folder.checkPermission(permission);
+        folder.checkPermission(permission);
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction/configfiles.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction/configfiles.jelly
@@ -20,8 +20,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-${it.CONFIGURE}
 -->
 
 <?jelly escape-by-default='true'?>
@@ -33,7 +31,6 @@ ${it.CONFIGURE}
 		<cf:sitepanel />
 
 		<l:main-panel>
-    		<j:out value="${it.permissionGranted}" />
 			<h1>
 				<img src="${it.getIconUrl(rootURL)}" alt="" />
 				<j:out value=" " />

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction/configfiles.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction/configfiles.jelly
@@ -20,16 +20,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+${it.CONFIGURE}
 -->
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 		 xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:cf="/lib/configfiles">
-	<l:layout permission="${app.ADMINISTER}" norefresh="true">
+	<l:layout permission="${it.CONFIGURE}" norefresh="true">
+
 
 		<cf:sitepanel />
 
 		<l:main-panel>
+    		<j:out value="${it.permissionGranted}" />
 			<h1>
 				<img src="${it.getIconUrl(rootURL)}" alt="" />
 				<j:out value=" " />


### PR DESCRIPTION
allow manage (CRUD) config files on folders without the requirement of the global ADMINISTER permission. it requires Job.CONFIGURE permission (Folder=Job)
