### PR TITLE
Delete per-provider configuration files that are not needed any longer

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -128,9 +128,10 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
     public void clearOldDataStorage() {
         if(configs != null && !configs.isEmpty()) {
             configs = Collections.emptyMap();
-            save();
+            File file = getConfigXml().getFile();
+            if (!file.delete()) {
+                LOGGER.info("Unable to delete " + file.getAbsolutePath());
+            }
         }
     }
-
-
 }

--- a/src/test/java/org/jenkinsci/lib/configprovider/SystemConfigFilesManagementTest.java
+++ b/src/test/java/org/jenkinsci/lib/configprovider/SystemConfigFilesManagementTest.java
@@ -1,7 +1,6 @@
-package org.jenkinsci.plugins.configfiles;
+package org.jenkinsci.lib.configprovider;
 
-import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
-import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,8 +25,9 @@ public class SystemConfigFilesManagementTest {
         for (ConfigProvider cp : ConfigProvider.all()) {
             // as all the config files have been moved to global config,
             // all providers must not hold any files any more
-            Assert.assertTrue(((AbstractConfigProviderImpl) cp).getConfigs().isEmpty());
+            AbstractConfigProviderImpl acp = (AbstractConfigProviderImpl) cp;
+            Assert.assertTrue(acp.getConfigs().isEmpty());
+            Assert.assertFalse(acp.getConfigXml().getFile().exists());
         }
-
     }
 }


### PR DESCRIPTION
This has 2 advantages:

- Do not let dangling "empty" files on disk never to be used again.
- In case of plugin downgrade, those are picked up and deserialized causing providers to use unmodifiable list as backing collection causing its manipulation will blow up badly:

```
java.lang.UnsupportedOperationException
	at java.util.AbstractMap.put(AbstractMap.java:209)
	at org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl.save(AbstractConfigProviderImpl.java:75)
	at org.jenkinsci.plugins.configfiles.ConfigFilesManagement.doSaveConfig(ConfigFilesManagement.java:120)
```