### PR TITLE
[JENKINS-42262] Add API where extension point could implement own logic for the content

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -28,16 +28,21 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.FilePath;
 import hudson.model.Descriptor;
 import hudson.model.ItemGroup;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.util.ReflectionUtils;
 import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * A ConfigProvider represents a configuration file (such as Maven's settings.xml) where the user can choose its actual content among several {@linkplain Config concrete contents} that are
@@ -190,4 +195,21 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
         GlobalConfigFiles.get().save(config);
         this.save();
     }
+
+    /**
+     * Provide the given content file.
+     *
+     * @param configFile the file content to be provided
+     * @param workDir target workspace directory
+     * @param listener the listener
+     * @param tempFiles temp files created by this method, these files will
+     *                  be deleted by the caller
+     * @return file content
+     * @throws IOException in case an exception occurs when providing the content or other needed files
+     * @since 2.16
+     */
+    public String supplyContent(@NonNull Config configFile, Run<?, ?> build, FilePath workDir, TaskListener listener, @NonNull List<String> tempFiles) throws IOException {
+        return configFile.content;
+    }
+
 }

--- a/src/main/java/org/jenkinsci/lib/configprovider/util/ConfigFileManager.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/util/ConfigFileManager.java
@@ -1,0 +1,133 @@
+/*
+ The MIT License
+
+ Copyright (c) 2011, Dominik Bartholdi, Olivier Lamy
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.lib.configprovider.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.Build;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.WorkspaceList;
+
+public class ConfigFileManager {
+    /**
+     * TODO use 1.652 use WorkspaceList.tempDir
+     *
+     * @param ws workspace of the {@link hudson.model.Build}. See {@link Build#getWorkspace()}
+     * @return temporary directory, may not have been created so far
+     */
+    public static FilePath tempDir(FilePath ws) {
+        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+    }
+
+    /**
+     * Provisions (publishes) the given files to the workspace.
+     *
+     * @param fileId config identifier to be provisioned
+     * @param targetLocation a custom target location where provide the config file or {@literal null} to provide file in a default secure location
+     * @param replaceTokens if {@literal true} performs the variable substitution of the config file content
+     * @param env enhanced environment to use in the variable substitution
+     * @param build a build being run
+     * @param workspace a workspace of the build
+     * @param listener a way to report progress
+     * @param tempFiles temp files created in this method, these files should be deleted by the caller
+     * @return path of the remote location of the config
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws AbortException in case config file has not been found
+     */
+    public static FilePath provisionConfigFile(@NonNull String fileId, @Nullable String targetLocation, boolean replaceTokens, @Nullable EnvVars env,
+            Run<?, ?> build, FilePath workspace, TaskListener listener, @NonNull List<String> tempFiles) throws IOException, InterruptedException {
+        Config configFile = ConfigFiles.getByIdOrNull(build, fileId);
+
+        if (configFile == null) {
+            String message = "not able to provide the file " + fileId + ", can't be resolved by any provider - maybe it got deleted by an administrator?";
+            listener.getLogger().println(message);
+            throw new AbortException(message);
+        }
+
+        FilePath workDir = tempDir(workspace);
+        workDir.mkdirs();
+
+        boolean createTempFile = StringUtils.isBlank(targetLocation);
+
+        FilePath target;
+        if (createTempFile) {
+            target = workDir.createTempFile("config", "tmp");
+        } else {
+
+            String expandedTargetLocation = targetLocation;
+            try {
+                expandedTargetLocation = TokenMacro.expandAll(build, workspace, listener, targetLocation);
+            } catch (MacroEvaluationException e) {
+                listener.getLogger().println("[ERROR] failed to expand variables in target location '" + targetLocation + "' : " + e.getMessage());
+                expandedTargetLocation = targetLocation;
+            }
+
+            // Should treat given path as the actual filename unless it has a trailing slash (implying a
+            // directory) or path already exists in workspace as a directory.
+            target = new FilePath(workspace, expandedTargetLocation);
+            String immediateFileName = expandedTargetLocation.substring(expandedTargetLocation.lastIndexOf("/") + 1);
+
+            if (immediateFileName.length() == 0 || (target.exists() && target.isDirectory())) {
+                target = new FilePath(target, configFile.name.replace(" ", "_"));
+            }
+        }
+
+        ConfigProvider provider = configFile.getDescriptor();
+        String fileContent = provider.supplyContent(configFile, build, workDir, listener, tempFiles);
+
+        if (replaceTokens) {
+            try {
+                fileContent = TokenMacro.expandAll(build, workspace, listener, fileContent);
+                if (env != null) {
+                    fileContent = Util.replaceMacro(fileContent, env);
+                }
+            } catch (MacroEvaluationException e) {
+                listener.getLogger().println("[ERROR] failed to expand variables in content of " + configFile.name + " - " + e.getMessage());
+            }
+        }
+
+        ByteArrayInputStream bs = new ByteArrayInputStream(fileContent.getBytes("UTF-8"));
+        target.copyFrom(bs);
+        target.chmod(0640);
+
+        return target;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -23,11 +23,6 @@
  */
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
-import hudson.AbortException;
-import hudson.FilePath;
-import hudson.model.*;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -35,29 +30,16 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.lib.configprovider.util.ConfigFileManager;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
-import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
-import org.jenkinsci.plugins.configfiles.maven.security.HasServerCredentialMappings;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
-import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import hudson.slaves.WorkspaceList;
+import hudson.AbortException;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 public class ManagedFileUtil {
     private final static Logger LOGGER = Logger.getLogger(ManagedFileUtil.class.getName());
-
-    /**
-     * TODO use 1.652 use WorkspaceList.tempDir
-     *
-     * @param ws workspace of the {@link hudson.model.Build}. See {@link Build#getWorkspace()}
-     * @return temporary directory, may not have been created so far
-     */
-    public static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
-    }
 
     /**
      * provisions (publishes) the given files to the workspace.
@@ -77,82 +59,19 @@ public class ManagedFileUtil {
         listener.getLogger().println("provisioning config files...");
 
         for (ManagedFile managedFile : managedFiles) {
+            FilePath target = ConfigFileManager.provisionConfigFile(managedFile.fileId, managedFile.targetLocation,
+                    managedFile.getReplaceTokens(), null, build, workspace, listener, tempFiles);
 
             Config configFile = ConfigFiles.getByIdOrNull(build, managedFile.fileId);
-
-            if (configFile == null) {
-                String message = "not able to provide the file " + managedFile + ", can't be resolved by any provider - maybe it got deleted by an administrator?";
-                listener.getLogger().println(message);
-                throw new AbortException(message);
+            if (configFile != null) {
+                // null check is guarantee by provisionConfigFile
+                LOGGER.log(Level.FINE, "Create file {0} for configuration {1} mapped as {2}", new Object[] { target.getRemote(), configFile, managedFile });
+                listener.getLogger().println(Messages.console_output(configFile.name, target.toURI()));
             }
-
-            FilePath workDir = tempDir(workspace);
-            workDir.mkdirs();
-
-            boolean createTempFile = StringUtils.isBlank(managedFile.targetLocation);
-
-            FilePath target;
-            if (createTempFile) {
-                target = workDir.createTempFile("config", "tmp");
-            } else {
-
-                String expandedTargetLocation = managedFile.targetLocation;
-                try {
-                    expandedTargetLocation = TokenMacro.expandAll(build, workspace, listener, managedFile.targetLocation);
-                } catch (MacroEvaluationException e) {
-                    listener.getLogger().println("[ERROR] failed to expand variables in target location '" + managedFile.targetLocation + "' : " + e.getMessage());
-                    expandedTargetLocation = managedFile.targetLocation;
-                }
-
-                // Should treat given path as the actual filename unless it has a trailing slash (implying a
-                // directory) or path already exists in workspace as a directory.
-                target = new FilePath(workspace, expandedTargetLocation);
-                String immediateFileName = expandedTargetLocation.substring(expandedTargetLocation.lastIndexOf("/") + 1);
-
-                if (immediateFileName.length() == 0 || (target.exists() && target.isDirectory())) {
-                    target = new FilePath(target, configFile.name.replace(" ", "_"));
-                }
-            }
-
-            // Inserts Maven server credentials if config files are Maven settings
-            String fileContent = insertCredentialsInSettings(build, configFile, workDir, tempFiles);
-
-            if (managedFile.getReplaceTokens()) {
-                try {
-                    fileContent = TokenMacro.expandAll(build, workspace, listener, fileContent);
-                } catch (MacroEvaluationException e) {
-                    listener.getLogger().println("[ERROR] failed to expand variables in content of " + configFile.name + " - " + e.getMessage());
-                }
-            }
-
-            LOGGER.log(Level.FINE, "Create file {0} for configuration {1} mapped as {2}", new Object[]{target.getRemote(), configFile, managedFile});
-            listener.getLogger().println(Messages.console_output(configFile.name, target.toURI()));
-            ByteArrayInputStream bs = new ByteArrayInputStream(fileContent.getBytes("UTF-8"));
-            target.copyFrom(bs);
-            target.chmod(0640);
             file2Path.put(managedFile, target);
         }
 
         return file2Path;
     }
 
-    private static String insertCredentialsInSettings(Run<?, ?> build, Config configFile, FilePath workDir, List<String> tempFiles) throws IOException {
-        String fileContent = configFile.content;
-
-        if (configFile instanceof HasServerCredentialMappings) {
-            HasServerCredentialMappings settings = (HasServerCredentialMappings) configFile;
-            final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, settings.getServerCredentialMappings());
-            final Boolean isReplaceAll = settings.getIsReplaceAll();
-
-            if (!resolvedCredentials.isEmpty()) {
-                try {
-                    fileContent = CredentialsHelper.fillAuthentication(fileContent, isReplaceAll, resolvedCredentials, workDir, tempFiles);
-                } catch (Exception exception) {
-                    throw new IOException("[ERROR] could not insert credentials into the settings file " + configFile, exception);
-                }
-            }
-        }
-
-        return fileContent;
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.configfiles.maven.job;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
@@ -19,8 +18,8 @@ import jenkins.mvn.GlobalSettingsProviderDescriptor;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.lib.configprovider.util.ConfigFileManager;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
-import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFileUtil;
 import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
@@ -88,7 +87,7 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
 
                         FilePath workspace = build.getWorkspace();
                         if (workspace != null) {
-                            FilePath workDir = ManagedFileUtil.tempDir(workspace);
+                            FilePath workDir = ConfigFileManager.tempDir(workspace);
                             String fileContent = config.content;
 
                             final Map<String, StandardUsernameCredentials> resolvedCredentials = CredentialsHelper.resolveCredentials(build, config.getServerCredentialMappings());

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.configfiles.maven.job;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
@@ -19,8 +18,8 @@ import jenkins.mvn.SettingsProviderDescriptor;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.lib.configprovider.util.ConfigFileManager;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
-import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFileUtil;
 import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
@@ -90,7 +89,7 @@ public class MvnSettingsProvider extends SettingsProvider {
 
                         FilePath workspace = build.getWorkspace();
                         if (workspace != null) {
-                            FilePath workDir = ManagedFileUtil.tempDir(workspace);
+                            FilePath workDir = ConfigFileManager.tempDir(workspace);
                             String fileContent = config.content;
 
                             final List<ServerCredentialMapping> serverCredentialMappings = config.getServerCredentialMappings();


### PR DESCRIPTION
Add a public manager that can be used as API by extension point to manage provisioning of configuration files that delegate to the config provider the business logic of the content.