### PR TITLE
Fix pipeline tests under windows node

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
@@ -83,9 +83,10 @@ public class ConfigFileBuildWrapperWorkflowTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
+                        + "def xsh(file) { if (isUnix()) {sh \"cat $file\"} else {bat \"type $file\"} }\n"
                         + "node {\n"
                         + "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt']]]) {\n"
-                        + "    sh 'cat myfile.txt'\n"
+                        + "    xsh 'myfile.txt'\n"
                         + "  }\n"
                         + "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -100,8 +101,11 @@ public class ConfigFileBuildWrapperWorkflowTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
+                        + "def xsh(file) { if (isUnix()) {sh \"cat $file\"} else {bat \"type $file\"} }\n"
                         + "node {\n"
-                        + "  configFileProvider([configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {sh 'cat myfile.txt'}\n"
+                        + "  configFileProvider([configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {\n"
+                        + "    xsh 'myfile.txt'\n"
+                        + "  }\n"
                         + "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 story.j.assertLogContains("some content", b);
@@ -115,8 +119,11 @@ public class ConfigFileBuildWrapperWorkflowTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
+                        + "def xsh(file) { if (isUnix()) {sh \"cat $file\"} else {bat \"type $file\"} }\n"
                         + "node {\n"
-                        + "  configFileProvider(managedFiles: [configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {sh 'cat myfile.txt'}\n"
+                        + "  configFileProvider(managedFiles: [configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {\n"
+                        + "    xsh 'myfile.txt'\n"
+                        + "  }\n"
                         + "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 story.j.assertLogContains("some content", b);
@@ -133,7 +140,7 @@ public class ConfigFileBuildWrapperWorkflowTest {
                         + "node {\n"
                         + "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + createConfig().id + "', variable: 'MYFILE']]]) {\n"
                         + "    semaphore 'withTempFilesAfterRestart'\n"
-                        + "    sh 'cat $MYFILE'\n"
+                        + "    if (isUnix()) {sh 'cat $MYFILE'} else {bat 'type %MYFILE%'}\n"
                         + "  }\n"
                         + "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();

--- a/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileActionTest.java
@@ -128,14 +128,21 @@ public class FolderConfigFileActionTest {
     }
 
     private CpsFlowDefinition getNewJobDefinition() {
-        return new CpsFlowDefinition(""
-                + "node {\n" +
-                "    configFileProvider([configFile(fileId: 'my-file-id', variable: 'MY_FILE')]) {\n" +
-                "       sh '''\n" +
-                "       ls -al $MY_FILE\n" +
-                "       cat $MY_FILE\n" +
-                "       '''\n" +
-                "   }\n" +
+        return new CpsFlowDefinition("" +
+                "node {\n" +
+                "  configFileProvider([configFile(fileId: 'my-file-id', variable: 'MY_FILE')]) {\n" +
+                "    if (isUnix()) {\n" +
+                "      sh '''\n" +
+                "      ls -al $MY_FILE\n" +
+                "      cat $MY_FILE\n" +
+                "      '''\n" +
+                "    } else {\n" +
+                "      bat '''\n" +
+                "      dir /a %MY_FILE%\n" +
+                "      type %MY_FILE%\n" +
+                "      '''\n" +
+                "    }\n" +
+                "  }\n" +
                 "}", true);
     }
 


### PR DESCRIPTION
Fix pipeline tests under windows node using the pipeline `isUnix()` function that permits to use `bat` command instead `sh`