### PR TITLE
[JENKINS-43372] use inherited @DataBoundSetter for providerId

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
@@ -38,11 +38,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class CustomConfig extends Config {
     private static final long serialVersionUID = 1L;
 
+    @DataBoundConstructor
     public CustomConfig(String id, String name, String comment, String content) {
         super(id, name, comment, content);
     }
 
-    @DataBoundConstructor
     public CustomConfig(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, content, providerId);
     }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/groovy/GroovyScript.java
@@ -39,11 +39,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class GroovyScript extends Config {
     private static final long serialVersionUID = 1L;
 
+    @DataBoundConstructor
     public GroovyScript(String id, String name, String comment, String content) {
         super(id, name, comment, content);
     }
 
-    @DataBoundConstructor
     public GroovyScript(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, content, providerId);
     }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/json/JsonConfig.java
@@ -42,11 +42,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class JsonConfig extends Config {
     private static final long serialVersionUID = 1L;
 
+    @DataBoundConstructor
     public JsonConfig(String id, String name, String comment, String content) {
         super(id, name, comment, fixJsonContent(content));
     }
 
-    @DataBoundConstructor
     public JsonConfig(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, fixJsonContent(content), providerId);
     }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig.java
@@ -42,11 +42,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class MavenToolchainsConfig extends Config {
     private static final long serialVersionUID = 1L;
 
+    @DataBoundConstructor
     public MavenToolchainsConfig(String id, String name, String comment, String content) {
         super(id, name, comment, content);
     }
 
-    @DataBoundConstructor
     public MavenToolchainsConfig(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, content, providerId);
     }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/xml/XmlConfig.java
@@ -38,11 +38,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class XmlConfig extends Config {
     private static final long serialVersionUID = 1L;
 
+    @DataBoundConstructor
     public XmlConfig(String id, String name, String comment, String content) {
         super(id, name, comment, content);
     }
 
-    @DataBoundConstructor
     public XmlConfig(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, content, providerId);
     }


### PR DESCRIPTION
Several subclasses of `Config` inherit a `@DataBoundSetter` for `providerId` but also require a `@DataBoundConstructor` argument for `providerId`. DSLs built with structs-plugin interpret `@DataBoundSetter` as optional arguments and `@DataBoundConstructor` as mandatory arguments. In this case it's ambiguous and should be fixed.

This PR changes `providerId` to be an optional argument. I'm not sure if this is correct and whether there should be a reasonable default value. E.g. `MavenSettingsConfig` and `GlobalMavenSettingsConfig` apply a default value. This could probalby also be implemented for the other config classes.