### PR TITLE
[JENKINS-43787] GlobalMavenSettingsConfig#getServerCredentialMappings() should never return null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig.java
@@ -64,7 +64,7 @@ public class GlobalMavenSettingsConfig extends Config implements HasServerCreden
     }
 
     public List<ServerCredentialMapping> getServerCredentialMappings() {
-        return serverCredentialMappings;
+        return serverCredentialMappings == null ? new ArrayList<ServerCredentialMapping>() : serverCredentialMappings;
     }
 
     public Boolean getIsReplaceAll() {


### PR DESCRIPTION
[JENKINS-43787](https://issues.jenkins-ci.org/browse/JENKINS-43787) GlobalMavenSettingsConfig#getServerCredentialMappings() should never return null to be consistent with MavenSettingsConfig#getServerCredentialMappings()