### PR TITLE
[JENKINS-45110] Adapt ConfigFileBuildWrapperWorkflowTest due to JENKINS-43073

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency> <!-- FilePathUtils -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.15</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperWorkflowTest.java
@@ -96,24 +96,6 @@ public class ConfigFileBuildWrapperWorkflowTest {
         });
     }
 
-    @Test public void symbolWithTargetLocation_Pipeline_short() throws Exception {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(""
-                        + "def xsh(file) { if (isUnix()) {sh \"cat $file\"} else {bat \"type $file\"} }\n"
-                        + "node {\n"
-                        + "  configFileProvider([configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {\n"
-                        + "    xsh 'myfile.txt'\n"
-                        + "  }\n"
-                        + "}", true));
-                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains("some content", b);
-                story.j.assertLogNotContains("temporary files", b);
-            }
-        });
-    }
-
     @Test public void symbolWithTargetLocation() throws Exception {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
@@ -121,7 +103,7 @@ public class ConfigFileBuildWrapperWorkflowTest {
                 p.setDefinition(new CpsFlowDefinition(""
                         + "def xsh(file) { if (isUnix()) {sh \"cat $file\"} else {bat \"type $file\"} }\n"
                         + "node {\n"
-                        + "  configFileProvider(managedFiles: [configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {\n"
+                        + "  configFileProvider([configFile(fileId: '" + createConfig().id + "', targetLocation: 'myfile.txt')]) {\n"
                         + "    xsh 'myfile.txt'\n"
                         + "  }\n"
                         + "}", true));


### PR DESCRIPTION
[JENKINS-45110](https://issues.jenkins-ci.org/browse/JENKINS-45110)

There is no reason to continue testing a deprecated syntax that make the test fail against `workflow-cps:2.14+`, for example when running the [Plugin Compat Tester](https://github.com/jenkinsci/plugin-compat-tester) 

@reviewbybees 