### PR TITLE
[JENKINS-46925] add support for custom folder types.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -56,21 +56,12 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
 
     @Override
     public String getIconFileName() {
-        // whilst you may be able to read configuration of a ComputedFolder they are not configurable, so the link should never be shown.
-        boolean hasPerm = folder.hasPermission(Item.EXTENDED_READ);
-        if (hasPerm) {
-            // check that the thing can store configuration (ie it is ultimately configurable)
-            // need to do this as System as a user with EXTENDED_READ but not configure should still see this.
-            // TODO use ACL.as when baseline is 2.14+
-            final SecurityContext impersonate = ACL.impersonate(ACL.SYSTEM);
-            try {
-                hasPerm = folder.hasPermission(Item.CONFIGURE);
-            }
-            finally {
-                SecurityContextHolder.setContext(impersonate);
-            }
-        }
-        
+        /*
+         * only show the action if you can either
+         * a) add a new entry
+         * b) there is an existing entry
+         */
+        boolean hasPerm = folder.hasPermission(Item.CONFIGURE) || (folder.hasPermission(Item.EXTENDED_READ) && hasStore());
         return hasPerm ? ConfigFilesManagement.ICON_PATH : null;
     }
 
@@ -139,6 +130,10 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
             e.printStackTrace();
         }
         return new HttpRedirect("index");
+    }
+
+    private boolean hasStore() {
+        return folder.getProperties().get(FolderConfigFileProperty.class) != null;
     }
 
     ConfigFileStore getStore() {

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -1,17 +1,15 @@
 package org.jenkinsci.plugins.configfiles.folder;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
-import hudson.Extension;
-import hudson.Util;
-import hudson.model.Action;
-import hudson.model.Item;
-import hudson.model.Job;
-import hudson.model.TopLevelItem;
-import hudson.security.Permission;
-import hudson.util.FormValidation;
-import jenkins.model.Jenkins;
-import jenkins.model.TransientActionFactory;
-import net.sf.json.JSONObject;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.servlet.ServletException;
+
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -21,11 +19,25 @@ import org.jenkinsci.plugins.configfiles.ConfigFilesUIContract;
 import org.jenkinsci.plugins.configfiles.Messages;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.HttpRedirect;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerProxy;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.*;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Action;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.security.Permission;
+import hudson.util.FormValidation;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+
+import jenkins.model.TransientActionFactory;
+import net.sf.json.JSONObject;
 
 public class FolderConfigFileAction implements Action, ConfigFilesUIContract, StaplerProxy {
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -34,20 +34,20 @@ import hudson.model.Job;
 import hudson.security.Permission;
 import hudson.util.FormValidation;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
 
 public class FolderConfigFileAction implements Action, ConfigFilesUIContract, StaplerProxy {
 
-    private Folder folder;
+    private AbstractFolder<?> folder;
 
-    FolderConfigFileAction(Folder folder) {
+    FolderConfigFileAction(AbstractFolder<?> folder) {
         this.folder = folder;
     }
 
-    public Folder getFolder() {
+    public AbstractFolder<?> getFolder() {
         return folder;
     }
 
@@ -108,7 +108,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
 
     @Override
     public HttpResponse doSaveConfig(StaplerRequest req) throws IOException, ServletException {
-        checkPermission(Job.CONFIGURE);
+        checkPermission(Item.CONFIGURE);
         try {
             JSONObject json = req.getSubmittedForm().getJSONObject("config");
             Config config = req.bindJSON(Config.class, json);
@@ -159,7 +159,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
 
     @Override
     public void doAddConfig(StaplerRequest req, StaplerResponse rsp, @QueryParameter("providerId") String providerId, @QueryParameter("configId") String configId) throws IOException, ServletException {
-        checkPermission(Job.CONFIGURE);
+        checkPermission(Item.CONFIGURE);
 
         FormValidation error = null;
         if (providerId == null || providerId.isEmpty()) {
@@ -228,14 +228,15 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
     }
 
     @Extension(optional = true)
-    public static class ActionFactory extends TransientActionFactory<Folder> {
+    @SuppressWarnings("rawtypes")
+    public static class ActionFactory extends TransientActionFactory<AbstractFolder> {
         @Override
-        public Class<Folder> type() {
-            return Folder.class;
+        public Class<AbstractFolder> type() {
+            return AbstractFolder.class;
         }
 
         @Override
-        public Collection<? extends Action> createFor(Folder target) {
+        public Collection<? extends Action> createFor(AbstractFolder target) {
             return Collections.singleton(new FolderConfigFileAction(target));
         }
     }


### PR DESCRIPTION
[JENKINS-46925](https://issues.jenkins-ci.org/browse/JENKINS-46925)

It looks like the code was mostly working with `AbstractFolder` however  the important Action was looking for types of Folder thus a user was not able to add configuration to those types of jobs.  This widens the type to `AbstractFolder`.

This is not binary compatable with old code calling `FolderConfigiFileAction`, but I could not find any occurrences in the wild.

Any existing configuration should be re-read without issues.

and example of these are `jenkins.branch.OrganizationFolder` and `org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject`  (whose parent is not an OrganisationFolder)

Generally I think this can be simplified to be any `AbstractFolder` that is not an descendant of a `ComputedFolder`, which in turn can be simplified to any `AbstractFolder` that can be configured, which is what is implemented in this PR (this is already taken care of in the WorkflowMultiBranchProject [ACL](https://github.com/jenkinsci/branch-api-plugin/blob/22c8d12a5ad3b523042343bb769b15affb11d1a6/src/main/java/jenkins/branch/MultiBranchProject.java#L750-L768).

Tested manually with an OrganizationFolder and a MultiBranch project that the config files are present in the UI and can be used in the jobs.

@reviewbybees 