### PR TITLE
[JENKINS-48476] PCT fails against core 2.73+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
         <java.level>7</java.level>
         <findbugs.failOnError>true</findbugs.failOnError>
@@ -140,10 +140,6 @@
                     <groupId>org.jenkins-ci.plugins.workflow</groupId>
                     <artifactId>workflow-step-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>script-security</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -151,12 +147,6 @@
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.13</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>script-security</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
         <java.level>7</java.level>
         <findbugs.failOnError>true</findbugs.failOnError>
+        <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
+        <workflow-support-plugin.version>2.16</workflow-support-plugin.version>
     </properties>
 
     <developers>
@@ -86,7 +88,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.3</version>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -107,7 +109,7 @@
         <dependency> <!-- FilePathUtils -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.20</version>
+            <version>2.22</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -138,6 +140,10 @@
                     <groupId>org.jenkins-ci.plugins.workflow</groupId>
                     <artifactId>workflow-step-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>script-security</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -145,19 +151,37 @@
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.13</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>script-security</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.11</version>
+            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow-support-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
See [JENKINS-48476](https://issues.jenkins-ci.org/browse/JENKINS-48476)

### Features:

- Upgrade test dependency: jenkins-core:2.73 needs upper pipeline version.
- Upgrade baseline to jenkins.version:2.7.3, the one needed for that pipeline version.

@reviewbybees 
@olamy 