### PR TITLE
[JENKINS-53247] support configuration as code 

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -24,6 +24,7 @@ import jenkins.model.Jenkins;
 
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.jenkinsci.plugins.configfiles.json.JsonConfig;
 
 /**
@@ -108,6 +109,10 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
     @Deprecated
     protected XmlFile getConfigXml() {
         return new XmlFile(Jenkins.XSTREAM, new File(Jenkins.getActiveInstance().getRootDir(), this.getXmlFileName()));
+    }
+
+    static {
+        Jenkins.XSTREAM.alias("org.jenkinsci.lib.configprovider.model.Config", CustomConfig.class);
     }
 
     @Deprecated

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * @author domi
  */
 @SuppressWarnings("serial")
-public class Config implements Serializable, Describable<Config> {
+public abstract class Config implements Serializable, Describable<Config> {
 
     /**
      * a unique id along all providers!
@@ -72,7 +72,6 @@ public class Config implements Serializable, Describable<Config> {
      */
     private String providerId;
 
-    @DataBoundConstructor
     public Config(String id, String name, String comment, String content) {
         this.id = id == null ? String.valueOf(System.currentTimeMillis()) : id;
         this.name = name;


### PR DESCRIPTION
GlobalConfigFiles is converted to a GlobalConfiguration so it get detected as a configuration target by casc.
Config is made abstract, so casc will check concrete implementation candidates when applying yaml.

see use with casc: https://github.com/jenkinsci/configuration-as-code-plugin/pull/507