### PR TITLE
Support to Configuration-As-Code plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>3.2</version>
+    <version>3.3-SNAPSHOT</version>
 
     <packaging>hpi</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>3.2</version>
 
     <packaging>hpi</packaging>
 

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/Config.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * @author domi
  */
 @SuppressWarnings("serial")
-public class Config implements Serializable, Describable<Config> {
+public abstract class Config implements Serializable, Describable<Config> {
 
     /**
      * a unique id along all providers!
@@ -72,7 +72,6 @@ public class Config implements Serializable, Describable<Config> {
      */
     private String providerId;
 
-    @DataBoundConstructor
     public Config(String id, String name, String comment, String content) {
         this.id = id == null ? String.valueOf(System.currentTimeMillis()) : id;
         this.name = name;

--- a/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
@@ -44,6 +44,11 @@ public class GlobalConfigFiles extends Descriptor<GlobalConfigFiles> implements 
         return this;
     }
 
+    @Override
+    public String getId() {
+        return "configfiles";
+    }
+
     public static GlobalConfigFiles get() {
         GlobalConfigFiles instance = Jenkins.getActiveInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         if (instance == null) { // TODO would be useful to have an ExtensionList.getOrFail


### PR DESCRIPTION
This fix makes the plugin compatible as casc.

- it depends on:  [#573](https://github.com/jenkinsci/configuration-as-code-plugin/pull/573)

> The pull request [#54](https://github.com/jenkinsci/config-file-provider-plugin/pull/54) implements the [GlobalConfiguration](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/GlobalConfiguration.java) Descriptor, but this generates an error in the config screen because this plugin does not have a global config.jelly  and setting the "getGlobalConfigPage" to null generates an fix in casc


- Sample Config ( usage in root section ) 
```
globalConfigFiles:
  configs:
    - custom:
        id: sample-custom-config
        name: SampleCustomConfig
        comment: dummy custom 1
        content: dummy content 1

    - json:
        id: sample-json-config
        name: SampleJsonConfig
        comment: sample json config
        content: |
          { "dummydata": {"dummyKey": "dummyValue"} }
    - xml:
        id: sample-xml-config
        name: SampleXmlConfig
        comment: dummy xml config
        content: <root><dummy test="abc"></dummy></root>
    - groovyScript:
        id: sample-jenkinsfile
        name: Jenkinsfile
        comment: Sample Jenkinsfile
        content: |
            @Library('sample_lib') _

            runPipeline([])

    - mavenSettings:
        id: default-maven-config
        name: Def Maven Config
        comment: Default | maven config settings
        isReplaceAll: false
        serverCredentialMappings:
        - serverId: nexus-id
          credentialsId: nexus_userpwd
        content: |
          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
                  .....
          </settingsa```
