### PR TITLE
Add ability to skip build failure if the config file is missing

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigFile.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigFile.java
@@ -33,11 +33,20 @@ public class ConfigFile implements Serializable {
     private final String fileId;
     protected String targetLocation;
     protected boolean replaceTokens;
+    protected boolean allowEmpty;
 
+    @Deprecated
     public ConfigFile(String fileId, String targetLocation, boolean replaceTokens) {
         this.fileId = fileId;
         this.targetLocation = Util.fixEmptyAndTrim(targetLocation);
         this.replaceTokens = replaceTokens;
+    }
+
+    public ConfigFile(String fileId, String targetLocation, boolean replaceTokens, boolean allowEmpty) {
+        this.fileId = fileId;
+        this.targetLocation = Util.fixEmptyAndTrim(targetLocation);
+        this.replaceTokens = replaceTokens;
+        this.allowEmpty = allowEmpty;
     }
 
     public String getFileId() {
@@ -50,6 +59,10 @@ public class ConfigFile implements Serializable {
 
     public boolean isReplaceTokens() {
         return replaceTokens;
+    }
+
+    public boolean getAllowEmpty() {
+        return allowEmpty;
     }
 
 }

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigFileManager.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigFileManager.java
@@ -79,6 +79,9 @@ public class ConfigFileManager {
         if (config == null) {
             String message = "not able to provide the file " + configFile + ", can't be resolved by any provider - maybe it got deleted by an administrator?";
             listener.getLogger().println(message);
+            if (configFile.getAllowEmpty()) {
+                return null;
+            }
             throw new AbortException(message);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
@@ -55,16 +55,21 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
      */
     @DataBoundConstructor
     public ManagedFile(String fileId) {
-        super(fileId, null, false);
+        super(fileId, null, false, false);
+    }
+
+    public ManagedFile(String fileId, String targetLocation, String variable, Boolean replaceTokens, boolean allowEmpty) {
+        super(fileId, targetLocation, replaceTokens, allowEmpty);
+        this.variable = Util.fixEmptyAndTrim(variable);
     }
 
     public ManagedFile(String fileId, String targetLocation, String variable, Boolean replaceTokens) {
-        super(fileId, targetLocation, replaceTokens);
+        super(fileId, targetLocation, replaceTokens, false);
         this.variable = Util.fixEmptyAndTrim(variable);
     }
 
     public ManagedFile(String fileId, String targetLocation, String variable) {
-        super(fileId, targetLocation, false);
+        super(fileId, targetLocation, false, false);
         this.variable = Util.fixEmptyAndTrim(variable);
     }
 
@@ -85,6 +90,11 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
     @DataBoundSetter
     public void setReplaceTokens(Boolean replaceTokens) {
         this.replaceTokens = replaceTokens != null ? replaceTokens : false;
+    }
+
+    @DataBoundSetter
+    public void setAllowEmpty(Boolean allowEmpty) {
+        this.allowEmpty = allowEmpty != null ? allowEmpty : false;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -55,7 +55,9 @@ public class ManagedFileUtil {
 
         for (ManagedFile managedFile : managedFiles) {
             FilePath target = ConfigFileManager.provisionConfigFile(managedFile, null, build, workspace, listener, tempFiles);
-            file2Path.put(managedFile, target);
+            if (target != null) {
+                file2Path.put(managedFile, target);
+            }
         }
 
         return file2Path;


### PR DESCRIPTION
Hello

During using this plugin I faced with the situation when we should not fail build when config file doesn't exist. For example, when we have one config file in the repository and use it in case of jenkins config file absence. Therefore I decided to extend this plugin with the allowEmpty property that will allow me to do that. By default it will be false so then already existing logic won't be broken.

Thanks