### PR TITLE
Fixes [JENKINS-57417]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep.java
@@ -58,7 +58,7 @@ public class ConfigFileBuildStep extends Builder implements Serializable {
 
         List<String> tempFiles = new ArrayList<String>();
 
-        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, build.getWorkspace(), listener, tempFiles);
+        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, null, build, build.getWorkspace(), listener, tempFiles);
 
         for (String tempFile:tempFiles) {
             build.addAction(new CleanTempFilesAction(tempFile));

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java
@@ -63,7 +63,7 @@ public class ConfigFileBuildWrapper extends SimpleBuildWrapper {
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         List<String> tempFiles = new ArrayList<String>();
 
-        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, build, workspace, listener, tempFiles);
+        final Map<ManagedFile, FilePath> file2Path = ManagedFileUtil.provisionConfigFiles(managedFiles, initialEnvironment, build, workspace, listener, tempFiles);
         for (Map.Entry<ManagedFile, FilePath> entry : file2Path.entrySet()) {
             ManagedFile mf = entry.getKey();
             FilePath fp = entry.getValue();

--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFileUtil.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.EnvVars;
 import org.jenkinsci.lib.configprovider.model.ConfigFileManager;
 
 import hudson.AbortException;
@@ -36,6 +38,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 
 public class ManagedFileUtil {
+
     /**
      * provisions (publishes) the given files to the workspace.
      *
@@ -47,14 +50,34 @@ public class ManagedFileUtil {
      * @throws IOException
      * @throws InterruptedException
      * @throws AbortException       config file has not been found
+     *
+     * @deprecated Use method that provides 'env' instead.
      */
+    @Deprecated
     public static Map<ManagedFile, FilePath> provisionConfigFiles(List<ManagedFile> managedFiles, Run<?, ?> build, FilePath workspace, TaskListener listener, List<String> tempFiles) throws IOException, InterruptedException {
+        return provisionConfigFiles(managedFiles, null, build, workspace, listener, tempFiles);
+    }
+
+    /**
+     * provisions (publishes) the given files to the workspace.
+     *
+     * @param managedFiles the files to be provisioned
+     * @param env          enhanced environment to use in the variable substitution
+     * @param workspace    target workspace
+     * @param listener     the listener
+     * @param tempFiles    temp files created by this method, these files should be deleted by the caller
+     * @return a map of all the files copied, mapped to the path of the remote location, never <code>null</code>.
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws AbortException       config file has not been found
+     */
+    public static Map<ManagedFile, FilePath> provisionConfigFiles(List<ManagedFile> managedFiles, @Nullable EnvVars env, Run<?, ?> build, FilePath workspace, TaskListener listener, List<String> tempFiles) throws IOException, InterruptedException {
 
         final Map<ManagedFile, FilePath> file2Path = new HashMap<ManagedFile, FilePath>();
         listener.getLogger().println("provisioning config files...");
 
         for (ManagedFile managedFile : managedFiles) {
-            FilePath target = ConfigFileManager.provisionConfigFile(managedFile, null, build, workspace, listener, tempFiles);
+            FilePath target = ConfigFileManager.provisionConfigFile(managedFile, env, build, workspace, listener, tempFiles);
             file2Path.put(managedFile, target);
         }
 


### PR DESCRIPTION
Allows propagation of environment variables, such as those assigned by the credentials-binding-plugin, to configuration files in declarative pipelines.

Initially, I was looking for [ConfigFileBuildWrapper.setUp()](https://github.com/jenkinsci/config-file-provider-plugin/blob/master/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper.java#L66) to augment the environment of `build` with `initialEnvironment`; however, [Run.getEnvironment(TaskListener)](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Run.java#L2370) doesn't return anything mutable / persistent. Additionally, this limitation also prevented the token macro plugin from being [invoked](https://github.com/jenkinsci/config-file-provider-plugin/blob/master/src/main/java/org/jenkinsci/lib/configprovider/model/ConfigFileManager.java#L120) using a single call, without implementing a subclass that could augment the environment, or reimplementing the [TokenMacro.expandAll()](https://github.com/jenkinsci/token-macro-plugin/blob/master/src/main/java/org/jenkinsci/plugins/tokenmacro/TokenMacro.java#L214) method.