### PR TITLE
Upgrade JCasC dependency to fix IOException warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,13 +216,13 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.2</version>
+            <version>1.29</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.2</version>
+            <version>1.29</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>


### PR DESCRIPTION
Otherwise when running `GlobalConfigFilesTest` the following warning including a stacktrace has been logged on Jenkins startup:

> java.io.IOException: No such file: /Users/nicolas/java/src/github.com/jenkinsci/configuration-as-code/target/checkout/plugin/src/main/resources