### PR TITLE
Fix anonymous class serialization warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigByIdComparator.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigByIdComparator.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.configfiles;
+
+import org.jenkinsci.lib.configprovider.model.Config;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+public class ConfigByIdComparator implements Comparator<Config>, Serializable {
+
+    @Override
+    public int compare(Config c1, Config c2) {
+        return c1.id.compareTo(c2.id);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles$1.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles$1.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.configfiles;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * This class is required for XStream backward compatibility because {@link GlobalConfigFiles}
+ * formerly contained an anonymous inner class defining the comparator.
+ *
+ * For old XML configurations that still contain a comparator element as follows
+ * {@code <comparator class="org.jenkinsci.plugins.configfiles.GlobalConfigFiles$1"/>}
+ * XStream tries to resolve a class named exactly like this during deserialization.
+ *
+ * @deprecated replaced by {@link ConfigByIdComparator}
+ */
+@Deprecated
+@Restricted(DoNotUse.class)
+final class GlobalConfigFiles$1 extends ConfigByIdComparator {}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
@@ -30,12 +30,7 @@ import java.util.TreeSet;
 @Symbol("globalConfigFiles")
 public class GlobalConfigFiles extends GlobalConfiguration implements ConfigFileStore {
 
-    private static Comparator<Config> COMPARATOR = new Comparator<Config>() {
-        @Override
-        public int compare(Config o1, Config o2) {
-            return o1.id.compareTo(o2.id);
-        }
-    };
+    private static Comparator<Config> COMPARATOR = new ConfigByIdComparator();
 
     private static ConfigProviderComparator CONFIGPROVIDER_COMPARATOR = new ConfigProviderComparator();
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty$1.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty$1.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.configfiles.folder;
+
+import org.jenkinsci.plugins.configfiles.ConfigByIdComparator;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * This class is required for XStream backward compatibility because {@link FolderConfigFileProperty}
+ * formerly contained an anonymous inner class defining the comparator.
+ *
+ * For old XML configurations that still contain a comparator element as follows
+ * {@code <comparator class="org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty$1"/>}
+ * XStream tries to resolve a class named exactly like this during deserialization.
+ *
+ * @deprecated replaced by {@link ConfigByIdComparator}
+ */
+@Deprecated
+@Restricted(DoNotUse.class)
+final class FolderConfigFileProperty$1 extends ConfigByIdComparator {}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
@@ -8,6 +8,7 @@ import hudson.model.*;
 import net.sf.json.JSONObject;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigByIdComparator;
 import org.jenkinsci.plugins.configfiles.ConfigByNameComparator;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
 import org.jenkinsci.plugins.configfiles.ConfigProviderComparator;
@@ -16,15 +17,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.util.*;
 
-
 public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFolder<?>> implements ConfigFileStore {
 
-    private static Comparator<Config> COMPARATOR = new Comparator<Config>() {
-        @Override
-        public int compare(Config o1, Config o2) {
-            return o1.id.compareTo(o2.id);
-        }
-    };
+    private static Comparator<Config> COMPARATOR = new ConfigByIdComparator();
 
     private static ConfigProviderComparator CONFIGPROVIDER_COMPARATOR = new ConfigProviderComparator();
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest.java
@@ -1,20 +1,22 @@
-package org.jenkinsci.plugins.configfiles;
+package org.jenkinsci.plugins.configfiles.folder;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFileStore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
- * Test for {@link GlobalConfigFiles} to ensure reading data.
+ * Test for {@link FolderConfigFileProperty} to ensure reading data.
  */
-public class GlobalConfigFilesTest {
+public class FolderConfigFilesTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -28,7 +30,7 @@ public class GlobalConfigFilesTest {
     @LocalData
     @Test
     public void verifyLoadWithAnonymousInnerClassComparatorVar1() {
-        ConfigFileStore store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        ConfigFileStore store = ((Folder) j.jenkins.getItemByFullName("test-folder")).getAction(FolderConfigFileAction.class).getStore();
         Collection<Config> configs = store.getConfigs();
         assertThat(configs, hasSize(2));
     }

--- a/src/test/resources/org/jenkinsci/plugins/configfiles/GlobalConfigFilesTest/verifyLoadWithAnonymousInnerClassComparatorVar1/org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml
+++ b/src/test/resources/org/jenkinsci/plugins/configfiles/GlobalConfigFilesTest/verifyLoadWithAnonymousInnerClassComparatorVar1/org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml
@@ -4,8 +4,8 @@
     <comparator class="org.jenkinsci.plugins.configfiles.GlobalConfigFiles$1"/>
     <org.jenkinsci.plugins.configfiles.custom.CustomConfig>
       <id>e61a40f3-9d03-4448-bca1-e874f3fb1c45</id>
-      <name>dummyCustomConfig1</name>
-      <comment>Dummy Custom Config 1</comment>
+      <name>custom-config</name>
+      <comment>Dummy Custom Config</comment>
       <content>dummy content</content>
       <providerId>org.jenkinsci.plugins.configfiles.custom.CustomConfig</providerId>
     </org.jenkinsci.plugins.configfiles.custom.CustomConfig>
@@ -17,17 +17,6 @@
 &lt;settings&gt;
     &lt;interactiveMode&gt;false&lt;/interactiveMode&gt;
     &lt;localRepository&gt;${env.WORKSPACE}/.repository&lt;/localRepository&gt;
-    &lt;!-- 
-    &lt;proxies&gt;
-        &lt;proxy&gt;
-          &lt;id&gt;dummy-proxy&lt;/id&gt;
-            &lt;active&gt;true&lt;/active&gt;
-            &lt;protocol&gt;http&lt;/protocol&gt;
-            &lt;port&gt;8888&lt;/port&gt;
-            &lt;nonProxyHosts&gt;localhost&lt;/nonProxyHosts&gt;
-        &lt;/proxy&gt;
-    &lt;/proxies&gt;
-    --&gt;
 &lt;/settings&gt;</content>
       <providerId>org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig</providerId>
       <serverCredentialMappings/>

--- a/src/test/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest/verifyLoadWithAnonymousInnerClassComparatorVar1/jobs/test-folder/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest/verifyLoadWithAnonymousInnerClassComparatorVar1/jobs/test-folder/config.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@5.12">
+  <actions/>
+  <description/>
+  <properties>
+    <org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty plugin="config-file-provider@2.18">
+      <configs class="sorted-set">
+        <comparator class="org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty$1"/>
+        <org.jenkinsci.plugins.configfiles.custom.CustomConfig>
+          <id>e47beadf-b379-4d8a-9db9-ea373600d8eb</id>
+          <name>custom-config</name>
+          <comment>Dummy Custom Config</comment>
+          <content>dummy content</content>
+          <providerId>org.jenkinsci.plugins.configfiles.custom.CustomConfig</providerId>
+        </org.jenkinsci.plugins.configfiles.custom.CustomConfig>
+        <org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig>
+          <id>de351ee6-bf92-43e1-b0af-0c31f5819b68</id>
+          <name>global-maven-settings</name>
+          <comment>Dummy global Maven settings</comment>
+          <content>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;settings&gt;
+    &lt;interactiveMode&gt;false&lt;/interactiveMode&gt;
+    &lt;localRepository&gt;${env.WORKSPACE}/.repository&lt;/localRepository&gt;
+&lt;/settings&gt;</content>
+          <providerId>org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig</providerId>
+          <serverCredentialMappings/>
+          <isReplaceAll>true</isReplaceAll>
+        </org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig>
+      </configs>
+    </org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty>
+  </properties>
+  <views>
+    <hudson.model.AllView>
+      <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <healthMetrics/>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>


### PR DESCRIPTION
The warnings from org.jenkinsci.remoting.util.AnonymousClassWarnings have been:
> "Attempt to (de-)serialize anonymous class org.jenkinsci.plugins.configfiles.GlobalConfigFiles$1 ..."
> "Attempt to (de-)serialize anonymous class org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty$1 ..."

See https://wiki.jenkins.io/display/JENKINS/Serialization+of+anonymous+classes for more details on this topic.

There have already been other attempts to fix these warnings in c95c3dda0a71bccc8e3f53389f4982938a02441c and d6616d7bfa304b80b08d5ae529ea472ce374bf1f. It was reported in [JENKINS-53399](https://issues.jenkins-ci.org/browse/JENKINS-53399) that XStream backward compatibility was broken. Therefore they have been reverted in fab44849a2b944cece2e79704eed9f523a65a648.

This change also keeps XStream backward compatibility.

CC @jsoref 