### PR TITLE
Do not call ConfigFilesActionFactory on Pipeline Jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesActionFactory.java
@@ -1,9 +1,9 @@
 package org.jenkinsci.plugins.configfiles;
 
 import hudson.Extension;
+import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
 import jenkins.model.TransientActionFactory;
 
 import javax.annotation.Nonnull;
@@ -11,25 +11,25 @@ import java.util.Collection;
 import java.util.Collections;
 
 @Extension
-public class ConfigFilesActionFactory extends TransientActionFactory<Job> {
+public class ConfigFilesActionFactory extends TransientActionFactory<AbstractProject> {
     @Override
-    public Class<Job> type() {
-        return Job.class;
+    public Class<AbstractProject> type() {
+        return AbstractProject.class;
     }
 
     @Nonnull
     @Override
-    public Collection<? extends Action> createFor(@Nonnull Job job) {
-        if (job instanceof FreeStyleProject || isMavenJob(job)) {
-            return Collections.singletonList(new ConfigFilesAction(job));
+    public Collection<? extends Action> createFor(@Nonnull AbstractProject project) {
+        if (project instanceof FreeStyleProject || isMavenJob(project)) {
+            return Collections.singletonList(new ConfigFilesAction(project));
         }
         return Collections.emptyList();
     }
 
-    private boolean isMavenJob(Job job) {
+    private boolean isMavenJob(AbstractProject project) {
         try {
-            Class<?> mvnJobClass = Class.forName("hudson.maven.MavenModuleSet", false, job.getClass().getClassLoader());
-            return mvnJobClass.isAssignableFrom(job.getClass());
+            Class<?> mvnJobClass = Class.forName("hudson.maven.MavenModuleSet", false, project.getClass().getClassLoader());
+            return mvnJobClass.isAssignableFrom(project.getClass());
         } catch (ClassNotFoundException e) {
             return false;
         }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>
Prevent Pipeline jobs from throwing an exception entirely
Prevents stack traces such as
```
java.lang.Throwable.fillInStackTrace(Native Method)
java.lang.Throwable.fillInStackTrace(Throwable.java:784)
java.lang.Throwable.<init>(Throwable.java:288)
java.lang.Exception.<init>(Exception.java:84)
java.lang.ReflectiveOperationException.<init>(ReflectiveOperationException.java:75)
java.lang.ClassNotFoundException.<init>(ClassNotFoundException.java:82)
jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1373)
jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1326)
sun.reflect.GeneratedMethodAccessor22.invoke(Unknown Source)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
jenkins.ClassLoaderReflectionToolkit.invoke(ClassLoaderReflectionToolkit.java:44)
jenkins.ClassLoaderReflectionToolkit._findClass(ClassLoaderReflectionToolkit.java:81)
hudson.ClassicPluginStrategy$DependencyClassLoader.findClass(ClassicPluginStrategy.java:626)
java.lang.ClassLoader.loadClass(ClassLoader.java:418)
java.lang.ClassLoader.loadClass(ClassLoader.java:351)
jenkins.util.AntClassLoader.findBaseClass(AntClassLoader.java:1392)
jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1075)
java.lang.ClassLoader.loadClass(ClassLoader.java:351)
java.lang.Class.forName0(Native Method)
java.lang.Class.forName(Class.java:348)
org.jenkinsci.plugins.configfiles.ConfigFilesActionFactory.isMavenJob(ConfigFilesActionFactory.java:31)
org.jenkinsci.plugins.configfiles.ConfigFilesActionFactory.createFor(ConfigFilesActionFactory.java:23)
org.jenkinsci.plugins.configfiles.ConfigFilesActionFactory.createFor(ConfigFilesActionFactory.java:13)
hudson.model.Actionable.createFor(Actionable.java:114)
hudson.model.Actionable.getActions(Actionable.java:139)
io.jenkins.plugins.analysis.core.columns.IssuesTotalColumn.getTotal(IssuesTotalColumn.java:124)
sun.reflect.GeneratedMethodAccessor600.invoke(Unknown Source)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.commons.jexl.util.introspection.UberspectImpl$VelMethodImpl.invoke(UberspectImpl.java:258)
```
From being thrown within

We found this out when we were investigating poor load performance with repositories that have a large number of branches.

@imod could you PTAL