### PR TITLE
upgrade to jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
             <artifactId>maven-plugin</artifactId>
             <version>3.1</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -225,12 +225,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
             <version>1.35</version>

--- a/pom.xml
+++ b/pom.xml
@@ -227,15 +227,14 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.29</version>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <version>1.29</version>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>1.35</version>
             <scope>test</scope>
-            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,12 @@
             <version>3.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+            <scope>test</scope>
+        </dependency>
         <!--<dependency>-->
             <!--<groupId>org.jenkins-ci.plugins</groupId>-->
             <!--<artifactId>email-ext</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.55</version>
+        <version>3.56</version>
     </parent>
 
     <artifactId>config-file-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
@@ -64,7 +64,7 @@ public class ConfigFileBuildWrapperTest {
         final MavenModuleSet p = j.createProject(MavenModuleSet.class);
 
         // p.getBuildWrappersList().add(new ConfigFileBuildWrapper(managedFiles))
-        p.setMaven(ToolInstallations.configureMaven3().getName());
+        p.setMaven(ToolInstallations.configureMaven35().getName());
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize"); // -s ${MVN_SETTING}
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -48,7 +48,7 @@ public class MvnSettingsCredentialsTest {
 
         final MavenModuleSet p = j.createProject(MavenModuleSet.class);
 
-        p.setMaven(ToolInstallations.configureMaven3().getName());
+        p.setMaven(ToolInstallations.configureMaven35().getName());
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize");
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
@@ -130,7 +130,7 @@ public class MvnSettingsProviderTest {
 
         final FreeStyleProject p = jenkins.createFreeStyleProject();
 
-        String mvnName = ToolInstallations.configureMaven3().getName();
+        String mvnName = ToolInstallations.configureMaven35().getName();
         Config c1 = createSetting(mavenSettingProvider);
         Config c2 = createSetting(globalMavenSettingsConfigProvider);
 
@@ -151,7 +151,7 @@ public class MvnSettingsProviderTest {
 
         final FreeStyleProject p = jenkins.createFreeStyleProject();
 
-        String mvnName = ToolInstallations.configureMaven3().getName();
+        String mvnName = ToolInstallations.configureMaven35().getName();
 
         MvnSettingsProvider s1 = new MvnSettingsProvider("dummyId");
         MvnGlobalSettingsProvider s2 = new MvnGlobalSettingsProvider("dummyGlobalId");

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -41,7 +41,7 @@ public class SettingsEnvVarTest {
 
         final MavenModuleSet p = j.createProject(MavenModuleSet.class);
 
-        p.setMaven(ToolInstallations.configureMaven3().getName());
+        p.setMaven(ToolInstallations.configureMaven35().getName());
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize");
 


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a tests classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
jenkinsci/bom#164

Note: We'll need a release for PCT please