### PR TITLE
set management link category to CONFIGURATION

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
@@ -105,6 +105,10 @@ public class ConfigFilesManagement extends ManagementLink implements ConfigFiles
         return "configfiles";
     }
 
+    public String getCategoryName() {
+        return "CONFIGURATION";
+    }
+
     public ContentType getContentTypeForProvider(String providerId) {
         for (ConfigProvider provider : ConfigProvider.all()) {
             if (provider.getProviderId().equals(providerId)) {


### PR DESCRIPTION
For Jenkins 2.226+, move the "Managed files" link into the "Configuration" category.

See jenkinsci/jenkins#4546 for details about this new categories system.

See jenkinsci/configuration-as-code-plugin#1357, or jenkinsci/credentials-plugin#139 + jenkinsci/credentials-plugin#140 for examples of how it has been implemented in other plugins.

Note that implementing this does not require bumping jenkins core dependency to a recent version, so the change proposed here is really minimal.