### PR TITLE
Add credential management to custom files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
             <version>1.13</version>
         </dependency>

--- a/src/main/java/org/jenkinsci/lib/configprovider/model/ContentType.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/model/ContentType.java
@@ -70,7 +70,8 @@ public interface ContentType {
 
 	public enum DefinedType implements ContentType {
 		XML("xml", "application/xml"), HTML("htmlmixed", "text/html"), GROOVY(
-				"clike", "text/x-groovy"), PROPERTIES("properties", "text/x-properties");
+				"clike", "text/x-groovy"), PROPERTIES("properties", "text/x-properties"),
+				SHELL("shell", "text/x-sh");
 
 		public final String cmMode;
 		public final String mime;

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/AbstractCustomProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/AbstractCustomProvider.java
@@ -1,0 +1,64 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom;
+
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.lib.configprovider.model.ContentType;
+import org.jenkinsci.plugins.configfiles.custom.security.CustomConfigCredentialsHelper;
+import org.jenkinsci.plugins.configfiles.custom.security.HasCustomizedCredentialMappings;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractCustomProvider extends AbstractConfigProviderImpl {
+
+    @Override
+    public ContentType getContentType() {
+        return ContentType.DefinedType.SHELL;
+    }
+
+    @Override
+    public String supplyContent(Config configFile, Run<?, ?> build, FilePath workDir, TaskListener listener, List<String> tempFiles) throws IOException {
+
+        HasCustomizedCredentialMappings settings = (HasCustomizedCredentialMappings) configFile;
+
+        final Map<String, IdCredentials> resolvedCredentials = CustomConfigCredentialsHelper.resolveCredentials(build, settings.getCustomizedCredentialMappings(), listener);
+
+        String fileContent = super.supplyContent(configFile, build, workDir, listener, tempFiles);
+        if (!resolvedCredentials.isEmpty()) {
+            try {
+                fileContent = CustomConfigCredentialsHelper.fillAuthentication(build, workDir, listener, fileContent, resolvedCredentials);
+            } catch (Exception exception) {
+                throw new IOException("[ERROR] could not insert credentials into the settings file " + configFile, exception);
+            }
+        }
+        return fileContent;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/CustomConfig.java
@@ -23,30 +23,49 @@
  */
 package org.jenkinsci.plugins.configfiles.custom;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.plugins.configfiles.Messages;
+import org.jenkinsci.plugins.configfiles.custom.security.CustomizedCredentialMapping;
+import org.jenkinsci.plugins.configfiles.custom.security.HasCustomizedCredentialMappings;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class CustomConfig extends Config {
+public class CustomConfig extends Config implements HasCustomizedCredentialMappings {
     private static final long serialVersionUID = 1L;
 
-    @DataBoundConstructor
+    private List<CustomizedCredentialMapping> customizedCredentialMappings;
+
     public CustomConfig(String id, String name, String comment, String content) {
         super(id, name, comment, content);
+        this.customizedCredentialMappings = new ArrayList<CustomizedCredentialMapping>();
+    }
+
+    @DataBoundConstructor
+    public CustomConfig(String id, String name, String comment, String content, List<CustomizedCredentialMapping> customizedCredentialMappings) {
+        super(id, name, comment, content, CustomConfigProvider.class.getName());
+        this.customizedCredentialMappings = customizedCredentialMappings == null ? new ArrayList<CustomizedCredentialMapping>() : customizedCredentialMappings;
     }
 
     public CustomConfig(String id, String name, String comment, String content, String providerId) {
         super(id, name, comment, content, providerId);
+        this.customizedCredentialMappings = new ArrayList<CustomizedCredentialMapping>();
+    }
+
+    @Override
+    public List<CustomizedCredentialMapping> getCustomizedCredentialMappings() {
+        return customizedCredentialMappings == null ? new ArrayList<CustomizedCredentialMapping>() : customizedCredentialMappings;
     }
 
     @Extension(ordinal = 50)
-    public static class CustomConfigProvider extends AbstractConfigProviderImpl {
+    public static class CustomConfigProvider extends AbstractCustomProvider {
 
         public CustomConfigProvider() {
             load();
@@ -54,7 +73,7 @@ public class CustomConfig extends Config {
 
         @Override
         public ContentType getContentType() {
-            return null;
+            return ContentType.DefinedType.SHELL;
         }
 
         @Override
@@ -62,9 +81,9 @@ public class CustomConfig extends Config {
             return Messages.custom_provider_name();
         }
 
-        @NonNull
+        @Nonnull
         @Override
-        public CustomConfig newConfig(@NonNull String id) {
+        public CustomConfig newConfig(@Nonnull String id) {
             return new CustomConfig(id,
                 Messages.CustomConfig_SettingsName(),
                 Messages.CustomConfig_SettingsComment(),

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/CustomConfigCredentialsHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/CustomConfigCredentialsHelper.java
@@ -1,0 +1,137 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom.security;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.configfiles.custom.security.TokenValueMacro;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CustomConfigCredentialsHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(CustomConfigCredentialsHelper.class.getName());
+
+    /**
+     * hide constructor
+     */
+    private CustomConfigCredentialsHelper() {
+    }
+
+    public static Map<String, IdCredentials> resolveCredentials(Run<?, ?> build, final List<CustomizedCredentialMapping> customizedCredentialMappings, TaskListener listener) {
+
+        Map<String, IdCredentials> customizedCredentialsMap = new HashMap<>();
+        for (CustomizedCredentialMapping customizedCredentialMapping : customizedCredentialMappings) {
+            final String credentialsId = customizedCredentialMapping.getCredentialsId();
+            final String tokenKey = customizedCredentialMapping.getTokenKey();
+
+            List<DomainRequirement> domainRequirements = Collections.emptyList();
+            if (StringUtils.isNotBlank(tokenKey)) {
+                domainRequirements = Collections.singletonList(new TokenKeyRequirement(tokenKey));
+            }
+
+            final IdCredentials c = CredentialsProvider.findCredentialById(credentialsId, IdCredentials.class, build, domainRequirements);
+
+            if (c != null) {
+                customizedCredentialsMap.put(tokenKey, c);
+            } else {
+                listener.getLogger().println("Could not find credentials [" + credentialsId + "] for " + build);
+            }
+        }
+        return customizedCredentialsMap;
+    }
+
+    public static String fillAuthentication(Run<?, ?> build, FilePath workDir, TaskListener listener,
+            String customizedContent, Map<String, IdCredentials> customizedCredentialsMap)
+            throws MacroEvaluationException, IOException, InterruptedException {
+        List<TokenValueMacro> customizedMacroArray = new ArrayList<TokenValueMacro>();
+
+        customizedCredentialsMap.forEach((key, value) -> customizedMacroArray.addAll(createCredentialBasedToken(key, value)));
+
+	@SuppressWarnings("unchecked")
+        List<TokenMacro> tokenMacroArray = (List<TokenMacro>) (List<? extends TokenMacro>) customizedMacroArray;
+
+        return TokenValueMacro.expand(build, workDir, listener, customizedContent, false, tokenMacroArray);
+    }
+
+    private static List<TokenValueMacro> createCredentialBasedToken(final String tokenKey,
+            final IdCredentials credential)
+    {
+        List<TokenValueMacro> credentialTokens = new ArrayList<TokenValueMacro>();
+        String tokenValue = "";
+
+        if (credential instanceof StandardUsernamePasswordCredentials) {
+            StandardUsernamePasswordCredentials usernamePasswordCredentials = (StandardUsernamePasswordCredentials) credential;
+            tokenValue = usernamePasswordCredentials.getPassword().getPlainText();
+            String tokenUser = usernamePasswordCredentials.getUsername();
+
+            credentialTokens.add(new TokenValueMacro(tokenKey + "_USR", tokenUser));
+            credentialTokens.add(new TokenValueMacro(tokenKey + "_PSW", tokenValue));
+            tokenValue = tokenUser + ":" + tokenValue;
+        } else if (credential instanceof SSHUserPrivateKey) {
+            SSHUserPrivateKey sshUserPrivateKey = (SSHUserPrivateKey) credential;
+	    String tokenUser = sshUserPrivateKey.getUsername();
+
+	    credentialTokens.add(new TokenValueMacro(tokenKey + "_USR", tokenUser));
+
+            List<String> privateKeys = sshUserPrivateKey.getPrivateKeys();
+            if (privateKeys.isEmpty()) {
+                LOGGER.log(Level.WARNING, "Property {0}: not private key defined in {1}, skip", new Object[]{tokenKey, sshUserPrivateKey.getId()});
+            } else if (privateKeys.size() == 1) {
+                LOGGER.log(Level.FINE, "Property {0}: use {1}", new Object[]{tokenKey, sshUserPrivateKey.getId()});
+                tokenValue = privateKeys.get(0);
+            } else {
+                LOGGER.log(Level.WARNING, "Property {0}: more than ({1}) private key defined in {1}, use first private key", new Object[]{tokenKey, privateKeys.size(), sshUserPrivateKey.getId()});
+                tokenValue = privateKeys.get(0);
+            }
+        } else if (credential instanceof StringCredentials) {
+            StringCredentials stringCredentials = (StringCredentials) credential;
+            tokenValue = stringCredentials.getSecret().getPlainText();
+        }
+
+        credentialTokens.add(new TokenValueMacro(tokenKey, tokenValue));
+
+        return credentialTokens;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping.java
@@ -1,0 +1,124 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom.security;
+
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
+import hudson.security.ACL;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.io.Serializable;
+import java.util.Collections;
+
+public class CustomizedCredentialMapping extends AbstractDescribableImpl<CustomizedCredentialMapping> implements Serializable {
+
+    private final String tokenKey;
+    private final String credentialsId;
+
+    @DataBoundConstructor
+    public CustomizedCredentialMapping(String tokenKey, String credentialsId) {
+        this.tokenKey = tokenKey;
+        this.credentialsId = credentialsId;
+    }
+
+    public String getTokenKey() {
+        return tokenKey;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<CustomizedCredentialMapping> {
+
+        public ListBoxModel doFillCredentialsIdItems(
+                @AncestorInPath Item item,
+                @QueryParameter String credentialsId
+                ) {
+
+            StandardListBoxModel result = new StandardListBoxModel();
+            if (item == null) {
+                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return result.includeCurrentValue(credentialsId);
+                }
+                return result
+                        .includeMatchingAs(
+                                ACL.SYSTEM,
+                                Jenkins.get(),
+                                StandardUsernameCredentials.class,
+                                Collections.emptyList(),
+                                CredentialsMatchers.instanceOf(
+                                        StandardUsernameCredentials.class))
+                        .includeMatchingAs(
+                                ACL.SYSTEM,
+                                Jenkins.get(),
+                                StringCredentials.class,
+                                Collections.emptyList(),
+                                CredentialsMatchers.instanceOf(
+                                        StringCredentials.class))
+                        .includeCurrentValue(credentialsId);
+            }
+
+            if (!item.hasPermission(Item.EXTENDED_READ)
+                && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+                return result.includeCurrentValue(credentialsId);
+            }
+            return result
+                    .includeMatchingAs(
+                            item instanceof Queue.Task
+                                    ? Tasks.getAuthenticationOf((Queue.Task) item)
+                                    : ACL.SYSTEM,
+                            item,
+                            StandardUsernameCredentials.class,
+                            Collections.emptyList(),
+                            CredentialsMatchers.instanceOf(
+                                    StandardUsernameCredentials.class))
+                    .includeMatchingAs(
+                            item instanceof Queue.Task
+                                    ? Tasks.getAuthenticationOf((Queue.Task) item)
+                                    : ACL.SYSTEM,
+                            item,
+                            StringCredentials.class,
+                            Collections.emptyList(),
+                            CredentialsMatchers.instanceOf(
+                                    StringCredentials.class))
+                    .includeCurrentValue(credentialsId);
+
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/HasCustomizedCredentialMappings.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/HasCustomizedCredentialMappings.java
@@ -1,0 +1,32 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom.security;
+
+import java.util.List;
+
+public interface HasCustomizedCredentialMappings {
+
+    List<CustomizedCredentialMapping> getCustomizedCredentialMappings();
+
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenKeyRequirement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenKeyRequirement.java
@@ -1,0 +1,42 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom.security;
+
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
+import javax.annotation.CheckForNull;
+
+public class TokenKeyRequirement extends DomainRequirement {
+
+    private String tokenKey;
+
+    public TokenKeyRequirement(String tokenKey) {
+        this.tokenKey = tokenKey;
+    }
+
+    @CheckForNull
+    public String getTokenKey() {
+        return tokenKey;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenValueMacro.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenValueMacro.java
@@ -1,0 +1,94 @@
+/*
+ The MIT License
+
+ Copyright (c) 2020, Andrew Grimberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.configfiles.custom.security;
+
+import com.google.common.collect.ListMultimap;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.*;
+
+import java.io.IOException;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+
+@Extension
+public class TokenValueMacro extends DataBoundTokenMacro {
+    @Parameter
+    public String token = "";
+
+    @Parameter
+    public String value = "";
+
+    public TokenValueMacro(String token, String value) {
+        this.token = token;
+        this.value = value;
+    }
+
+    public TokenValueMacro() {
+    }
+
+    @Override
+    public boolean acceptsMacroName(String macroName) {
+        return macroName.equals(token);
+    }
+
+    @Override
+    public List<String> getAcceptedMacroNames() {
+        return Collections.singletonList(token);
+    }
+
+    @Override
+    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName)
+            throws MacroEvaluationException, IOException, InterruptedException {
+        return this.value;
+    }
+
+    @Override
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName)
+            throws MacroEvaluationException, IOException, InterruptedException {
+        return this.value;
+    }
+
+    @Override
+    public String evaluate(AbstractBuild<?, ?> build, TaskListener listener, String macroName,
+            Map<String, String> arguments, ListMultimap<String, String> argumentMultiMap)
+            throws MacroEvaluationException, IOException, InterruptedException {
+        return this.value;
+    }
+
+    @Override
+    public String evaluate(Run<?, ?> run, FilePath workspace, TaskListener listener, String macroName,
+            Map<String, String> arguments, ListMultimap<String, String> argumentMultiMap)
+            throws MacroEvaluationException, IOException, InterruptedException {
+        return this.value;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/show-config.jelly
@@ -10,6 +10,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
+	<j:set var="descriptor" value="${config.descriptor}"/>
+	<j:set var="instance" value="${config}"/>
 	<f:entry title="${%ID}">
 		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
 	</f:entry>
@@ -18,6 +20,9 @@
 	</f:entry>
 	<f:entry title="${%Comment}">
 		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
+	</f:entry>
+	<f:entry title="${%Tokenized Credentials}" field="customizedCredentialMappings">
+		<f:repeatableProperty field="customizedCredentialMappings" noAddButton="true" />
 	</f:entry>
 	<f:entry title="${%Content}">
 		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2013, Dominik Bartholdi
+Copyright (c) 2020, Andrew Grimberg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +25,18 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+         <f:entry title="${%Token}" field="tokenKey">
+             <f:textbox />
+         </f:entry>
 
-					<j:set var="instance" value="${config}"/>
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Tokenized Credentials}">
-						<f:repeatableProperty field="customizedCredentialMappings" />
-					</f:entry>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+         <f:entry title="${%Credentials}" field="credentialsId" >
+             <c:select />
+         </f:entry>
+
+         <f:entry title="" >
+            <div align="right">
+             <input type="button" value="${%Delete}" class="repeatable-delete" style="margin-left: 1em;" />
+             </div>
+         </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/help-credentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/help-credentialsId.html
@@ -1,0 +1,1 @@
+The credentials to be assigned to the token. This can be of the following types: Username/password, SSH Username/privatekey, Secret text

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/help-tokenKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/help-tokenKey.html
@@ -1,0 +1,10 @@
+The token that will be replaced with the credential information. The token is case sensitive and is traditionally represented as all uppercase.
+
+<p>A <b>TOKEN</b> for a username/password credential will be replaced in the following ways:<br>
+<b>$TOKEN</b> will be replaced with <b>username:password</b><br>
+<b>$TOKEN_PSW</b> will be replaced with just the <b>password</b><br>
+<b>$TOKEN_USR</b> will be replaced with just the <b>username</b></p>
+
+<p>A <b>token</b> for an SSH username/keypair credential will be replaced in the following ways:<br>
+<b>$token</b> will be replaced with the keypair or first key if loaded from file<br>
+<b>$token_USR</b> will be replaced with the <b>username</b></p>


### PR DESCRIPTION
With the advent of Jenkins Configuration As Code (JCasC) it has become
more needed to be able to provide a way to allow job owners to provide
new managed configuration files that also replace tokenized credentials.
While it is possible to attain this goal by utilizing the Credentials
Binding Plugin along with the 'Replace All' option when defining where
the file is put on disk during the job this has caused several problems
with well established methods of managing the jobs. In particular, jobs
being managed with Jenkins Job Builder which tend to be heavily
Freestyle in nature and also utilize a lot of templates and macros
suffer greatly when using this method of management.

Instead, allowing credentials to be defined and automatically replaced
when the file is rendered down to disk solves the problem of securely
storing the credentials in the credential store and also allowing less
privileged persons the ability to more easily work with the managed
files.

This change in particular modifies the 'custom' file type to support
defining credentials along with the tokens that are to be used and
having them properly rendered when being put down on disk. It will
continue to work fine with the previous method using the Credentials
Binding Plugin as well as it will only replace the tokens that it has a
full definition for and then would be passed through the full
environment token replacement as well as it did before this change.

Making this change allows for safe storage of configuration files in
JCasC format to be stored in a repository and in some fashion
manipulated into place for Jenkins to utilize (exercise for the admin)
which is a partial answer to JENKINS-17766. It also completely obviates
the requirement to encrypt the files as per JENKINS-18635 as the
sensitive data can now be securely separated from the non-sensitive
data.

Resolves: JENKINS-43204
Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>