### PR TITLE
Undepricate AbstractConfigProviderImpl#load()

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProviderImpl.java
@@ -87,7 +87,6 @@ public abstract class AbstractConfigProviderImpl extends ConfigProvider {
     /**
      * Overridden for backward compatibility to let subtype customize the file name.
      */
-    @Deprecated
     public void load() {
         XmlFile xml = getConfigXml();
         if (xml.exists()) {


### PR DESCRIPTION
[`hudson.model.Descriptor#load()`](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Descriptor.java#L903-L905) explicitly states that overriding classes must invoke this from their constructor.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
