### PR TITLE
Remove generated content from the wiki page

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,18 +5,6 @@ image:https://img.shields.io/jenkins/plugin/v/config-file-provider.svg[link="htt
 image:https://img.shields.io/github/release/jenkinsci/config-file-provider-plugin.svg?label=changelog[link="https://github.com/jenkinsci/config-file-provider-plugin/releases/latest"]
 image:https://img.shields.io/jenkins/plugin/i/config-file-provider.svg?color=blue[link="https://plugins.jenkins.io/config-file-provider"]
 
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
-* https://jenkins.io/security/advisory/2019-01-28/#SECURITY-1253[XSS
-vulnerability]
-* https://jenkins.io/security/advisory/2018-09-25/#SECURITY-938[Cross-site
-request forgery vulnerability]
-* https://jenkins.io/security/advisory/2017-08-07/[Users with
-Overall/Read access could access configuration files]
-* https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1080[Cross
-Site Scripting vulnerability]
-
 Adds the ability to provide configuration files (i.e., settings.xml for maven, XML, groovy, custom files, etc.) loaded through the Jenkins UI which will be copied to the job's workspace.
 
 == How it works


### PR DESCRIPTION
This content was generated by a wiki macro and has no reason to be part of the readme file. The plugin site has its own functionality to show past security warnings.

Origin branch out of laziness, delete on merge.