### PR TITLE
Increase version to 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>config-file-provider</artifactId>
-    <version>3.7.1-SNAPSHOT</version>
+    <version>3.8.0-SNAPSHOT</version>
 
     <packaging>hpi</packaging>
 


### PR DESCRIPTION
We treated 3.7.1 as a backport branch with divergent history on master, so I assume the next release will be 3.8.0.

Origin branch, please delete on merge.