### PR TITLE
Fix test for core versions above or equal to 2.266

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -9,6 +9,7 @@ import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException2;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
+import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;
 import org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider;
 import org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProvider;
@@ -27,7 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.fail;
 
 /**
@@ -142,8 +143,8 @@ public class Security2203Test {
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName("reader"))) {
             run.run(); // The method should fail
             fail(String.format("%s should be only accessible by people with the permission %s, but it's accessible by a person with %s", checkedMethod, permission, Item.READ));
-        } catch (AccessDeniedException2 e) {
-            assertThat(e.permission, equalTo(permission));
+        } catch (AccessDeniedException  e) {
+            assertThat(e.getMessage(), containsString(permission.group.title + "/" + permission.name));
         }
 
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName(userWithPermission.get(permission)))) {

--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -6,7 +6,6 @@ import hudson.model.ItemGroup;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.security.AccessDeniedException2;
 import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
@@ -313,7 +312,7 @@ public class Security2203Test {
 
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName(userWithPermission.get(permission)))) {
             run.run(); // The method doesn't fail
-        } catch (AccessDeniedException2 e) {
+        } catch (AccessDeniedException e) {
             fail(String.format("%s should be accessible to people with the permission %s but it failed with the exception: %s", checkedMethod, permission, e));
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -143,7 +143,7 @@ public class Security2203Test {
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName("reader"))) {
             run.run(); // The method should fail
             fail(String.format("%s should be only accessible by people with the permission %s, but it's accessible by a person with %s", checkedMethod, permission, Item.READ));
-        } catch (AccessDeniedException  e) {
+        } catch (AccessDeniedException e) {
             assertThat(e.getMessage(), containsString(permission.group.title + "/" + permission.name));
         }
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
@@ -1,18 +1,18 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.security.AccessDeniedException2;
 import hudson.security.Permission;
-import org.hamcrest.core.IsEqual;
+import org.acegisecurity.AccessDeniedException;
 
 import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.fail;
 
 /**
  * A class to run pieces of code with a certain user and assert either the code runs successfully, without even worrying
- * about the result, or the code fails with an {@link AccessDeniedException2} with the specified {@link Permission}.
+ * about the result, or the code fails with an {@link AccessDeniedException} with the specified {@link Permission} reason. 
  */
 public class PermissionChecker extends ProtectedCodeRunner<Void> {
     /**
@@ -26,16 +26,16 @@ public class PermissionChecker extends ProtectedCodeRunner<Void> {
     }
 
     /**
-     * Assert the execution of the code by this user fails with this permission. The code throws an {@link AccessDeniedException2}
-     * with the permission field being permission. Otherwise it fails.
+     * Assert the execution of the code by this user fails with this permission. The code throws an {@link AccessDeniedException}
+     * with the message indicating the same permission. Otherwise it fails.
      * @param permission The permission thrown by the code.
      */
     public void assertFailWithPermission(Permission permission) {
         Throwable t = getThrowable();
-        if (t instanceof AccessDeniedException2) {
-            assertThat(((AccessDeniedException2) t).permission, IsEqual.equalTo(permission));
+        if (t instanceof AccessDeniedException) {
+            assertThat(t.getMessage(), containsString(permission.group.title + "/" + permission.name));
         } else {
-            fail(String.format("The code run by %s didn't throw an AccessDeniedException2 with %s. If failed with the unexpected throwable: %s", getUser(), permission, t));
+            fail(String.format("The code run by %s didn't throw an AccessDeniedException with %s. If failed with the unexpected throwable: %s", getUser(), permission, t));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
-import hudson.security.AccessDeniedException2;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,10 +7,11 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
+import java.nio.file.AccessDeniedException;
 import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -42,7 +42,7 @@ public class ProtectedCodeRunnerTests {
         assertThat(checker.getResult(), is("allowed"));
 
         Throwable t = checker.withUser("reader").getThrowable(); 
-        assertThat(t, instanceOf(AccessDeniedException2.class));
-        assertThat(((AccessDeniedException2) t).permission, equalTo(Jenkins.ADMINISTER));
+        assertThat(t, instanceOf(AccessDeniedException.class));
+        assertThat(t.getMessage(), containsString(Jenkins.ADMINISTER.group.title + "/" + Jenkins.ADMINISTER.name));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
@@ -1,13 +1,13 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
 import jenkins.model.Jenkins;
+import org.acegisecurity.AccessDeniedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
-import java.nio.file.AccessDeniedException;
 import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
A security test fails for Jenkins versions above 2.266 because on those versions, Jenkins triggers an AccessDeniedException3, instead of the AccessDeniedException2.

This PR fixes this test.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
