### PR TITLE
JENKINS-65436 Fix null pointer exception

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -142,7 +142,7 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
             items.add("please select", "");
 
             if (!contextToCheck.hasPermission(permToCheck)) {
-                items.add("current", currentValue); // we just add what they send
+                items.add(new ListBoxModel.Option("current", currentValue, true)); // we just add what they send
                 return items;
             }
             

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -32,6 +32,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import org.kohsuke.stapler.QueryParameter;
 
 /**
  * This provider delivers the global settings.xml to the job during job/project execution. <br>
@@ -134,7 +135,7 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
             return "provided global settings.xml";
         }
 
-        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, String currentValue) {
+        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, @QueryParameter String settingsConfigId) {
             Permission permToCheck = project == null ? Jenkins.ADMINISTER : Item.EXTENDED_READ;
             AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
 
@@ -142,12 +143,12 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
             items.add("please select", "");
 
             if (!contextToCheck.hasPermission(permToCheck)) {
-                items.add(new ListBoxModel.Option("current", currentValue, true)); // we just add what they send
+                items.add(new ListBoxModel.Option("current", settingsConfigId, true)); // we just add what they send
                 return items;
             }
             
             for (Config config : ConfigFiles.getConfigsInContext(context, GlobalMavenSettingsConfigProvider.class)) {
-                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(currentValue)));
+                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(settingsConfigId)));
             }
             return items;
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -5,6 +5,8 @@ import hudson.FilePath;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
+import hudson.security.AccessControlled;
+import hudson.security.Permission;
 import hudson.slaves.WorkspaceList;
 import hudson.model.AbstractBuild;
 
@@ -15,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.GlobalSettingsProviderDescriptor;
 
@@ -132,7 +135,10 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
         }
 
         public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project) {
-            project.checkPermission(Item.CONFIGURE);
+            Permission permToCheck = project == null ? Jenkins.SYSTEM_READ : Item.EXTENDED_READ;
+            AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
+
+            contextToCheck.checkPermission(permToCheck);
             
             ListBoxModel items = new ListBoxModel();
             items.add("please select", "");

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnGlobalSettingsProvider.java
@@ -134,16 +134,20 @@ public class MvnGlobalSettingsProvider extends GlobalSettingsProvider {
             return "provided global settings.xml";
         }
 
-        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project) {
-            Permission permToCheck = project == null ? Jenkins.SYSTEM_READ : Item.EXTENDED_READ;
+        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, String currentValue) {
+            Permission permToCheck = project == null ? Jenkins.ADMINISTER : Item.EXTENDED_READ;
             AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
 
-            contextToCheck.checkPermission(permToCheck);
-            
             ListBoxModel items = new ListBoxModel();
             items.add("please select", "");
+
+            if (!contextToCheck.hasPermission(permToCheck)) {
+                items.add("current", currentValue); // we just add what they send
+                return items;
+            }
+            
             for (Config config : ConfigFiles.getConfigsInContext(context, GlobalMavenSettingsConfigProvider.class)) {
-                items.add(config.name, config.id);
+                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(currentValue)));
             }
             return items;
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -7,6 +7,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.model.Item;
+import hudson.security.AccessControlled;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
@@ -134,7 +137,10 @@ public class MvnSettingsProvider extends SettingsProvider {
         }
 
         public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project) {
-            project.checkPermission(Item.CONFIGURE);
+            Permission permToCheck = project == null ? Jenkins.SYSTEM_READ : Item.EXTENDED_READ;
+            AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
+
+            contextToCheck.checkPermission(permToCheck);
             
             ListBoxModel items = new ListBoxModel();
             items.add(Messages.MvnSettingsProvider_PleaseSelect(), "");

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -144,7 +144,7 @@ public class MvnSettingsProvider extends SettingsProvider {
             items.add(Messages.MvnSettingsProvider_PleaseSelect(), "");
 
             if (!contextToCheck.hasPermission(permToCheck)) {
-                items.add("current", currentValue); // we just add what they send
+                items.add(new ListBoxModel.Option("current", currentValue, true)); // we just add what they send
                 return items;
             }
             

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -32,6 +32,7 @@ import hudson.slaves.WorkspaceList;
 import hudson.util.ListBoxModel;
 import jenkins.mvn.SettingsProvider;
 import jenkins.mvn.SettingsProviderDescriptor;
+import org.kohsuke.stapler.QueryParameter;
 
 /**
  * This provider delivers the settings.xml to the job during job/project execution. <br>
@@ -136,7 +137,7 @@ public class MvnSettingsProvider extends SettingsProvider {
             return Messages.MvnSettingsProvider_ProvidedSettings();
         }
 
-        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, String currentValue) {
+        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, @QueryParameter String settingsConfigId) {
             Permission permToCheck = project == null ? Jenkins.ADMINISTER : Item.EXTENDED_READ;
             AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
 
@@ -144,12 +145,12 @@ public class MvnSettingsProvider extends SettingsProvider {
             items.add(Messages.MvnSettingsProvider_PleaseSelect(), "");
 
             if (!contextToCheck.hasPermission(permToCheck)) {
-                items.add(new ListBoxModel.Option("current", currentValue, true)); // we just add what they send
+                items.add(new ListBoxModel.Option("current", settingsConfigId, true)); // we just add what they send
                 return items;
             }
             
             for (Config config : ConfigFiles.getConfigsInContext(context, MavenSettingsConfigProvider.class)) {
-                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(currentValue)));
+                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(settingsConfigId)));
             }
             return items;
         }

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProvider.java
@@ -136,19 +136,22 @@ public class MvnSettingsProvider extends SettingsProvider {
             return Messages.MvnSettingsProvider_ProvidedSettings();
         }
 
-        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project) {
-            Permission permToCheck = project == null ? Jenkins.SYSTEM_READ : Item.EXTENDED_READ;
+        public ListBoxModel doFillSettingsConfigIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, String currentValue) {
+            Permission permToCheck = project == null ? Jenkins.ADMINISTER : Item.EXTENDED_READ;
             AccessControlled contextToCheck = project == null ? Jenkins.get() : project;
 
-            contextToCheck.checkPermission(permToCheck);
-            
             ListBoxModel items = new ListBoxModel();
             items.add(Messages.MvnSettingsProvider_PleaseSelect(), "");
+
+            if (!contextToCheck.hasPermission(permToCheck)) {
+                items.add("current", currentValue); // we just add what they send
+                return items;
+            }
+            
             for (Config config : ConfigFiles.getConfigsInContext(context, MavenSettingsConfigProvider.class)) {
-                items.add(config.name, config.id);
+                items.add(new ListBoxModel.Option(config.name, config.id, config.id.equals(currentValue)));
             }
             return items;
         }
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -101,7 +101,7 @@ public class Security2203Test {
      * The {@link MvnSettingsProvider.DescriptorImpl#doFillSettingsConfigIdItems(ItemGroup, Item, String)} is only accessible by 
      * administers.
      */
-    @Issue({"SECURITY-2203", "SECURITY-2203"})
+    @Issue({"SECURITY-2203", "JENKINS-65436"})
     @Test
     public void mvnSettingsProviderDoFillSettingsConfigIdItemsProtectedGlobalConfiguration() {
         r.jenkins.getInjector().injectMembers(this);
@@ -143,7 +143,7 @@ public class Security2203Test {
      * The {@link MvnSettingsProvider.DescriptorImpl#doFillSettingsConfigIdItems(ItemGroup, Item, String)} is only accessible by people able to
      * configure the job.
      */
-    @Issue({"SECURITY-2203", "SECURITY-2203"})
+    @Issue({"SECURITY-2203", "JENKINS-65436"})
     @Test
     public void mvnSettingsProviderDoFillSettingsConfigIdItemsProtectedForProject() {
         r.jenkins.getInjector().injectMembers(this);
@@ -186,7 +186,7 @@ public class Security2203Test {
      * The {@link MvnGlobalSettingsProvider.DescriptorImpl#doFillSettingsConfigIdItems(ItemGroup, Item, String)} is only accessible by people able to
      * administer Jenkins.
      */
-    @Issue({"SECURITY-2203", "SECURITY-2203"})
+    @Issue({"SECURITY-2203", "JENKINS-65436"})
     @Test
     public void mvnGlobalSettingsProviderDoFillSettingsConfigIdItemsProtectedGlobalConfiguration() {
         r.jenkins.getInjector().injectMembers(this);
@@ -228,7 +228,7 @@ public class Security2203Test {
      * The {@link MvnGlobalSettingsProvider.DescriptorImpl#doFillSettingsConfigIdItems(ItemGroup, Item, String)} is only accessible by people able to
      * configure the job.
      */
-    @Issue({"SECURITY-2203", "SECURITY-2203"})
+    @Issue({"SECURITY-2203", "JENKINS-65436"})
     @Test
     public void mvnGlobalSettingsProviderDoFillSettingsConfigIdItemsProtectedForProject() {
         r.jenkins.getInjector().injectMembers(this);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See https://issues.jenkins.io/browse/JENKINS-65436
Fix null pointer exceptions at Global Tool Configuration when checking the permission: project may be null.

In addition, we change the way we check permissions in those methods to instead of fail, return an empty list of items. Recommended way.

Plus test improvements.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
