### PR TITLE
Fix test errors because of change in security classes on new Jenkins core versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <jenkins.version>2.235.5</jenkins.version>
+        <jenkins.version>2.277</jenkins.version>
         <java.level>8</java.level>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
     </properties>
@@ -54,8 +54,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>19</version>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>29</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -71,6 +71,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
+            <!-- because asm update on 2.277: https://www.jenkins.io/doc/upgrade-guide/2.277/ -->
+            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <!-- because asm update on 2.277: https://www.jenkins.io/doc/upgrade-guide/2.277/ -->
-            <version>2.15</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/ConfigProvider.java
@@ -134,8 +134,10 @@ public abstract class ConfigProvider extends Descriptor<Config> implements Exten
 
     private void setField(String fieldName, String value, Config config) {
         Field field = ReflectionUtils.findField(config.getClass(), fieldName);
-        field.setAccessible(true);
-        ReflectionUtils.setField(field, config, value);
+        if (field != null) {
+            field.setAccessible(true);
+            ReflectionUtils.setField(field, config, value);
+        }
     }
 
     public abstract void clearOldDataStorage();

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.configfiles;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import jenkins.model.Jenkins;
-import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.junit.Assert;
@@ -11,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
+import org.springframework.security.access.AccessDeniedException;
 
 import javax.annotation.CheckForNull;
 import java.io.File;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -9,7 +9,7 @@ import hudson.security.ACLContext;
 import hudson.security.Permission;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import org.acegisecurity.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
@@ -2,8 +2,7 @@ package org.jenkinsci.plugins.configfiles.sec;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.security.Permission;
-import org.acegisecurity.AccessDeniedException;
-
+import org.springframework.security.access.AccessDeniedException;
 import java.util.function.Supplier;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunnerTests.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
 import jenkins.model.Jenkins;
-import org.acegisecurity.AccessDeniedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.function.Supplier;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Some acegisecurity classes were still over there. Those fixes were not complete: https://github.com/jenkinsci/config-file-provider-plugin/pull/124

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
