### PR TITLE
JENKINS-60498 reconcile configs collection type when set by CasC

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/GlobalConfigFiles.java
@@ -93,6 +93,7 @@ public class GlobalConfigFiles extends GlobalConfiguration implements ConfigFile
     /* only for CasC (Configuration as Code Plugin) */
     public void setConfigs(Collection<Config> configs) {
         this.configs = configs;
+        readResolve(); // ensure configs collection is a TreeSet
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesConfigAsCodeTest.java
@@ -1,8 +1,15 @@
 package org.jenkinsci.plugins.configfiles;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.TreeSet;
+
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -33,5 +40,21 @@ public class GlobalConfigFilesConfigAsCodeTest {
         Assert.assertNotNull(maven);
         Assert.assertFalse(maven.isReplaceAll);
         Assert.assertEquals("someCredentials", maven.getServerCredentialMappings().get(0).getCredentialsId());
+    }
+
+    /** @see https://issues.jenkins.io/browse/JENKINS-60498 */
+    @Test
+    public void ensure_configs_treeset() {
+        final Config[] testConfigs = {
+            new CustomConfig("1", "name1", "", ""),
+            new CustomConfig("2", "name2", "", "")
+        };
+
+        final GlobalConfigFiles cfg = GlobalConfigFiles.get();
+        cfg.setConfigs(Arrays.asList(testConfigs));
+
+        final Collection<Config> actualConfigs = cfg.getConfigs();
+        Assert.assertTrue("configs must be a TreeSet", actualConfigs instanceof TreeSet);
+        MatcherAssert.assertThat(actualConfigs, Matchers.containsInAnyOrder(testConfigs));
     }
 }


### PR DESCRIPTION
Fix for https://issues.jenkins.io/browse/JENKINS-60498

### Problem
When updating managed confiig files via CasC, the collection of Configs is set as a HashSet rather than the TreeSet required by the config-file-provider to ensure uniqueness of Config objects.
### Fix
After setting managed config files through CasC, call the already existing `readResolve()` method to reconcile the collection type to the required TreeSet.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
