### PR TITLE
[JENKINS-67122] Fix NPE in Pipeline Snippet Generator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
@@ -108,8 +108,10 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
 
         public ListBoxModel doFillFileIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project) {
             // You should have permission to configure your project in order to get the available managed files
-            project.checkPermission(Item.CONFIGURE);
-            
+            if (project != null) {
+                project.checkPermission(Item.CONFIGURE);
+            }
+
             ListBoxModel items = new ListBoxModel();
             items.add("please select", "");
             for (Config config : ConfigFiles.getConfigsInContext(context, null)) {
@@ -129,7 +131,9 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
         public HttpResponse doCheckFileId(StaplerRequest req, @AncestorInPath Item context, @QueryParameter String fileId) {
             // You should have permission to configure your project in order to check whether the selected file id is
             // allowed to you
-            context.checkPermission(Item.CONFIGURE);
+            if (context != null) {
+                context.checkPermission(Item.CONFIGURE);
+            }
             
             final Config config = ConfigFiles.getByIdOrNull(context, fileId);
             if (config != null) {


### PR DESCRIPTION
## [JENKINS-67122](https://issues.jenkins.io/browse/JENKINS-67122) Fix NPE in Pipeline Snippet Generator

The Pipeline snippet generator reports an exception when trying to generate a sample using configFileProvider.  It assumes the context is always not-null, yet in the context of the Pipeline syntax generator at the root, there is no context to be used.

See the issue locally by opening http://localhost:8080/jenkins/pipeline-syntax then selecting configFileProvider from the drop down list

A different issue is visible when opening from inside a job definition.  It reports HTTP error 403.  This change resolves both issues.  I'm not sure of the security issues that may be related to skipping the permission check when the request lacks context.  I assume that a request that lacks context should be answered.
