### PR TITLE
Fix invalid HTML page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show.jelly
@@ -25,8 +25,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<style>.CodeMirror {border: 2px inset #dee;}</style>
 	<l:layout norefresh="true">
+		<style>.CodeMirror {border: 2px inset #dee;}</style>
 		<l:main-panel>
 	
 			<f:form method="" action="">


### PR DESCRIPTION
Because the style declaration was outside of the layout, the generatedHTML had the style declaration before the head tag.

I believe this could be the source of a flaky text (`org.jenkinsci.plugins.configfiles.maven.job.MvnSettingsProviderTest`) mostly visible in PCT context.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
