### PR TITLE
Use https:// instead of git:// for public SCM repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/config-file-provider-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/config-file-provider-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/config-file-provider-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/config-file-provider-plugin</url>
         <tag>HEAD</tag>


### PR DESCRIPTION
## Update scm public URL in pom

GitHub has announced that they will deprecate the git:// access protocol in the future.

https://github.blog/2021-09-01-improving-git-protocol-security-github/ notes that Jan 11, 2022 will be the first brownout and Mar 15, 2022 will make the change permanent.

Depends on #155 