### PR TITLE
Use spotbugs instead of javax CheckForNull

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenKeyRequirement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/custom/security/TokenKeyRequirement.java
@@ -25,7 +25,7 @@ package org.jenkinsci.plugins.configfiles.custom.security;
 
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public class TokenKeyRequirement extends DomainRequirement {
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/MavenServerIdRequirement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/MavenServerIdRequirement.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.configfiles.maven.security;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 

--- a/src/main/java/org/jenkinsci/plugins/configfiles/properties/security/PropertyKeyRequirement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/properties/security/PropertyKeyRequirement.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.configfiles.properties.security;
 
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public class PropertyKeyRequirement extends DomainRequirement {
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
@@ -12,7 +12,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.springframework.security.access.AccessDeniedException;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;


### PR DESCRIPTION
## Use spotbugs instead of javax to import CheckForNull

JSR-305 was never completed, spotbugs is stable and usable.  Code is already using the spotbugs annotation in some of its source files.

Depends on #155 