### PR TITLE
Update plugin parent POM and forward compatibility for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.38</version>
+        <version>4.40</version>
         <relativePath />
     </parent>
 
@@ -29,10 +29,9 @@
     <properties>
         <revision>3.10.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/config-file-provider-plugin</gitHubRepo>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <jenkins.version>2.303.3</jenkins.version>
-        <java.level>8</java.level>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,11 @@
             <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>email-ext</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/test/java/org/jenkinsci/lib/configprovider/SystemConfigFilesManagementTest.java
+++ b/src/test/java/org/jenkinsci/lib/configprovider/SystemConfigFilesManagementTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.lib.configprovider;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.plugins.emailext.JellyTemplateConfig;
 import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
@@ -44,9 +45,9 @@ public class SystemConfigFilesManagementTest {
         Assert.assertEquals(1, getProvider(XmlConfig.XmlConfigProvider.class).getAllConfigs().size());
         Assert.assertEquals(1, getProvider(GroovyScript.GroovyConfigProvider.class).getAllConfigs().size());
         Assert.assertEquals(1, getProvider(CustomConfig.CustomConfigProvider.class).getAllConfigs().size());
-//        Assert.assertEquals(1, getProvider(JellyTemplateConfig.JellyTemplateConfigProvider.class).getAllConfigs().size());
+        Assert.assertEquals(1, getProvider(JellyTemplateConfig.JellyTemplateConfigProvider.class).getAllConfigs().size());
 
-        Assert.assertEquals(5, GlobalConfigFiles.get().getConfigs().size());
+        Assert.assertEquals(6, GlobalConfigFiles.get().getConfigs().size());
     }
 
     private <T> T getProvider(Class<T> providerClass) {

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesSEC1253Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesSEC1253Test.java
@@ -5,6 +5,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput;
+import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +56,8 @@ public class ConfigFilesSEC1253Test {
         assertThat(store.getConfigs(), hasSize(1));
 
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        String attribute = j.jenkins.getVersion().isOlderThan(new VersionNumber("2.324")) ? "onclick" : "data-url";
+        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@" + attribute + ", 'removeConfig?id=" + CONFIG_ID + "')]");
 
         AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);
         wc.setConfirmHandler((page, s) -> {
@@ -87,7 +89,8 @@ public class ConfigFilesSEC1253Test {
         JenkinsRule.WebClient wc = j.createWebClient();
 
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        String attribute = j.jenkins.getVersion().isOlderThan(new VersionNumber("2.324")) ? "onclick" : "data-url";
+        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@" + attribute + ", 'removeConfig?id=" + CONFIG_ID + "')]");
 
         AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);
         AtomicReference<Boolean> alertCalled = new AtomicReference<>(false);

--- a/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileActionTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.hudson.plugins.folder.Folder;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.Item;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -241,7 +242,8 @@ public class FolderConfigFileActionTest {
         // Clicking the button works
         // If we click on the link, it goes via POST, therefore it removes it successfully
         HtmlPage configFiles = wc.goTo(f1.getUrl() + "configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        String attribute = r.jenkins.getVersion().isOlderThan(new VersionNumber("2.324")) ? "onclick" : "data-url";
+        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@" + attribute + ", 'removeConfig?id=" + CONFIG_ID + "')]");
 
         AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);
         wc.setConfirmHandler((page, s) -> {

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2002Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2002Test.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.configfiles.sec;
 
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.util.VersionNumber;
 import jenkins.model.GlobalConfiguration;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
@@ -50,7 +51,8 @@ public class Security2002Test {
         // Clicking the button works
         // If we click on the link, it goes via POST, therefore it removes it successfully
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        String attribute = j.jenkins.getVersion().isOlderThan(new VersionNumber("2.324")) ? "onclick" : "data-url";
+        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@" + attribute + ", 'removeConfig?id=" + CONFIG_ID + "')]");
 
         AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);
         wc.setConfirmHandler((page, s) -> {


### PR DESCRIPTION
The underlying motivation for the parent POM update is that the new parent POM supports Java 17 and I want to do Java 17 testing of this plugin in `jenkinsci/bom`.

The underlying compatibility for the forward compatibility for tests is to support my ongoing efforts to switch plugin compatibility testing in `jenkinsci/bom` to use JENKINS-45047.

This change supersedes #184 (thank you @mikecirioli for the UI updates!). It contains the UI portions of that change without the controversial Jenkins baseline bump. The 4.40 parent POM update is unique to this PR.