### PR TITLE
Update `Jenkinsfile` and plugin parent POM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
-    [platform: 'linux', jdk: '11'],
-    [platform: 'windows', jdk: '11'],
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.59</version>
+        <version>4.61</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
This is required for https://github.com/jenkinsci/stapler/pull/452 so that tests continue passing in this plugin and in BOM.