### PR TITLE
[JENKINS-71414] Add DataBoundConstructor and Symbol to FolderConfigFileProperty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileAction.java
@@ -144,7 +144,7 @@ public class FolderConfigFileAction implements Action, ConfigFilesUIContract, St
         // TODO only add property when its really needed (eg. don't add it if there is no config to be saved)
         FolderConfigFileProperty folderConfigFileProperty = folder.getProperties().get(FolderConfigFileProperty.class);
         if(folderConfigFileProperty == null) {
-            folderConfigFileProperty = new FolderConfigFileProperty(folder);
+            folderConfigFileProperty = new FolderConfigFileProperty();
             try {
                 folder.addProperty(folderConfigFileProperty);
             } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
@@ -134,7 +134,7 @@ public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFol
     }
 
     @Extension(optional = true)
-    @Symbol("folderConfigFile")
+    @Symbol("folderConfigFiles")
     public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
@@ -6,16 +6,19 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import hudson.Extension;
 import hudson.model.*;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigByIdComparator;
 import org.jenkinsci.plugins.configfiles.ConfigByNameComparator;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
 import org.jenkinsci.plugins.configfiles.ConfigProviderComparator;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFolder<?>> implements ConfigFileStore {
 
@@ -23,12 +26,27 @@ public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFol
 
     private static ConfigProviderComparator CONFIGPROVIDER_COMPARATOR = new ConfigProviderComparator();
 
-    private Collection<Config> configs = new TreeSet<>(COMPARATOR);
+    private Collection<Config> configs;
 
-    private transient AbstractFolder<?> owner;
+    /*package*/ FolderConfigFileProperty() {
+        this((Collection<Config>) null);
+    }
 
+    @Deprecated
     /*package*/ FolderConfigFileProperty(AbstractFolder<?> owner) {
+        this((Collection<Config>)null);
         setOwner(owner);
+    }
+
+    @DataBoundConstructor
+    public FolderConfigFileProperty(Collection<Config> configs) {
+        if(configs != null) {
+            this.configs = configs
+                .stream()
+                .collect(Collectors.toCollection(() -> new TreeSet<>(COMPARATOR)));
+        } else {
+            this.configs = new TreeSet<>(COMPARATOR);
+        }
     }
 
     @Override
@@ -116,6 +134,7 @@ public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFol
     }
 
     @Extension(optional = true)
+    @Symbol("folderConfigFile")
     public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFileProperty.java
@@ -29,13 +29,7 @@ public class FolderConfigFileProperty extends AbstractFolderProperty<AbstractFol
     private Collection<Config> configs;
 
     /*package*/ FolderConfigFileProperty() {
-        this((Collection<Config>) null);
-    }
-
-    @Deprecated
-    /*package*/ FolderConfigFileProperty(AbstractFolder<?> owner) {
-        this((Collection<Config>)null);
-        setOwner(owner);
+        this(null);
     }
 
     @DataBoundConstructor


### PR DESCRIPTION
…r overload

* Added DataboundConstructor to the `FolderConfigFileProperty`
* Added symbol `folderConfigFile` to the property descriptor
* Remove `owner` overload that is un-necessary 
* Deprecated constructor

### Testing done

* Spin up Jenkins
* Create a Folder
* Add Folder config files
* Save

--> Validate the the config files are still there after save
--> Validate the the config files are still there after restart

* create a pipeline job in the folder:

    ```
    node {
        configFileProvider([configFile(fileId: '<fileID>, targetLocation: 'test.txt', variable: 'TEST')]) {
          sh "cat $TEST"
        }
    }
    ```

* Run the pipeline

--> Validate that it properly injects the file and the content is expected

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
