### PR TITLE
forward compatibility for core dialogs

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/configfiles/HtmlElementUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/HtmlElementUtil.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.configfiles;
+
+import java.io.IOException;
+import org.htmlunit.Page;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebClientUtil;
+import org.htmlunit.html.HtmlButton;
+import org.htmlunit.html.HtmlElement;
+
+public class HtmlElementUtil {
+  public HtmlElementUtil() {
+  }
+
+  public static void clickDialogOkButton(HtmlElement element, HtmlElement document) throws IOException {
+    if (element != null) {
+      boolean var6 = false;
+
+      try {
+        var6 = true;
+        element.click();
+        var6 = false;
+      } finally {
+        if (var6) {
+          WebClient var4 = element.getPage().getWebClient();
+          WebClientUtil.waitForJSExec(var4);
+        }
+      }
+
+      WebClient webClient = element.getPage().getWebClient();
+      WebClientUtil.waitForJSExec(webClient);
+      HtmlButton confirmButton = document.getOneHtmlElementByAttribute("button", "data-id", "ok");
+      confirmButton.click();
+    }
+  }
+}


### PR DESCRIPTION
Change https://github.com/jenkinsci/jenkins/pull/7938 released with 2.415 introduces native dialogs as replacement of browser dialogs. Make the tests work with both variants.

<!-- Please describe your pull request here. -->

### Testing done

run tests against 2.414 and 2.415 and both succeeded

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
