### PR TITLE
Annotate deprecated class to silence compiler warning

### DIFF
--- a/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
+++ b/src/main/java/org/jenkinsci/lib/configprovider/AbstractConfigProvider.java
@@ -37,6 +37,7 @@ import jenkins.model.Jenkins;
  * 
  * @deprecated as of 1.2. Extend {@link AbstractConfigProviderImpl} directly.
  */
+@Deprecated
 public abstract class AbstractConfigProvider extends AbstractConfigProviderImpl {
 
     protected final String ID_PREFIX = this.getClass().getSimpleName() + ".";


### PR DESCRIPTION
## Annotate deprecated class to silence compiler warning

dd3167229e61b075c8c2abfc1c205662fdf12460 deprecated the class in 2012 with a Javadoc comment.  Add the `@Deprecated` annotation to silence the Java compiler warning that a deprecated class does not have the `@Deprecated` annotation.

### Testing done

Confirmed the compiler warning message no longer appears when the annotation is added.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
