### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
     </properties>
 
@@ -55,8 +55,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2423.vce598171d115</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -144,24 +144,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- conflicts with used httpclient -->
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.22</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jsoup</groupId>
-                    <artifactId>jsoup</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

The existing plugins that depend on the config file provider plugin have a wide range of Jenkins minimum versions.  As far as I can tell, increasing the Jenkins minimum required version from 2.361.4 to 2.387.3 will not create a problem for most users of the plugin.

Users that are running recent versions of the plugin are already using Jenkins 2.387.3 or newer.

Users that are running much older versions are not upgrading the plugin version so won't be affected by an increase of minimum Jenkins version because they probably won't install the new plugin release.

https://stats.jenkins.io/pluginversions/config-file-provider.html shows

* 34% of all installations of the config file provider plugin are already running Jenkins 2.387.3 or newer.  Those users will be able to upgade to the version that requires Jenkins 2.387.3 without changing their Jenkins core version
* 94% of the 11900 installations of the most recent release (953.xxx) are already running Jenkins 2.387.3 or newer. Requiring Jenkins 2.387.3 or newer is no change for them
* 93% of the 11700 installations of the next most recent release (952.xxx) are already running Jenkins 2.387.3 or newer.  Requiring Jenkins 2.387.3 or newer is no change for them

Plugins that depend on the config file provider plugin include:

* Artifactory - requires 2.235.5 or newer, no additional problems when requiring 2.387.3 or newer
* Ivy - requires 2.361.4 or newer, with open security vulnerability and up for adoption
* JClouds - requires 2.332.1 or newer, no additional problems when requiring 2.387.3 or newer
* Managed Scripts - requires 2.319.3 or newer, no additional problems when requiring 2.387.3 or newer
* NodeJS - already requires 2.387.3 or newer
* OpenStack Cloud 0 requires 2.289.1 or newer, no additional problems when requiring 2.387.3 or newer
* Pipeline Dependency Walker - requires 1.642.4 or newer, no additional problems when requiring 2.387.3 or newer
* Pipeline Maven Integration - requires 2.361.4 or newer
* Pipeline NPM Integration - already requires 2.387.3 or newer
* Pipeline: Multibranch with defaults - requires Jenkin 2.130 or newer, no additional problems when requiring 2.387.3 or newer

### Testing done

Confirmed automated tests pass on my Linux machine with Java 11 and Java 17.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
