### PR TITLE
Run ci.jenkins.io tests in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
   [platform: 'linux', jdk: 17],
   [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
## Run ci.jenkins.io tests in parallel

Save time and money by testing in parallel with all the cores available on agents of ci.jenkins.io.

Allow developer control of parallel testing

Developers are allowed to configure the amount of parallel testing based on the configuration and use of their computer.  This allows developers to configure test parallelism based on their environment and still allow ci.jenkins.io to reduce costs by running tests in parallel.

Developers can adjust parallel execution by passing a command line argument to Maven like this:

  mvn clean -DforkCount=1C verify

Developers can define a Maven profile that sets the forkCount in their ~/.m2/settings.xml like this:

  <profile>
    <id>faster</id>
    <activation>
      <activeByDefault>true</activeByDefault>
    </activation>
    <properties>
      <forkCount>.45C</forkCount>
    </properties>
  </profile>

With that entry in the settings.xml file, then 0.45C will be used for:

  mvn clean verify

Supersedes https://github.com/jenkinsci/config-file-provider-plugin/pull/283

### Testing done

Confirmed tests pass on Java 11, Java 17, and Java 21 with forkCount=1C on my Linux computer.

Rely on ci.jenkins.io to test Windows.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
