### PR TITLE
Adjust credentials masking tests for base64 masking improvement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
     </properties>
 
@@ -55,8 +55,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2423.vce598171d115</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -144,24 +144,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion> <!-- conflicts with used httpclient -->
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.22</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jsoup</groupId>
-                    <artifactId>jsoup</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
+            <version>636.v55f1275c7b_27</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfigTest.java
@@ -88,7 +88,7 @@ public class MavenSettingsConfigTest {
     @Before
     public void before() {
         GlobalConfigFiles.get().save(new MavenSettingsConfig("m2settings", "m2settings", "", "<settings/>", true, 
-                Collections.singletonList(new ServerCredentialMapping("myserver", createCredential("creds", "bot", "s3cr3t").getId()))));
+                Collections.singletonList(new ServerCredentialMapping("myserver", createCredential("creds", "bot-user-name", "bot-user-s3cr3t").getId()))));
         GlobalConfigFiles.get().save(new GlobalMavenSettingsConfig("m2GlobalSettings", "m2GlobalSettings", "", "<settings/>", true, 
                 Collections.singletonList(new ServerCredentialMapping("myGlobalServer", createCredential("creds2", "admin", "sensitive").getId()))));
 
@@ -104,8 +104,8 @@ public class MavenSettingsConfigTest {
                 "    String settings = readFile(env.SETTINGS)",
                 "    echo settings",
                 "    if (!settings.equals('<settings/>')) {", //Build #2 won't have credentials to assert on
-                "      assert settings.contains('<password>s3cr3t</password>')",
-                "      assert settings.contains('<username>bot</username>')",
+                "      assert settings.contains('<password>bot-user-s3cr3t</password>')",
+                "      assert settings.contains('<username>bot-user-name</username>')",
                 "    }",
                 "    settings = readFile(env.GOBAL_SETTINGS)",
                 "    echo settings",
@@ -116,14 +116,14 @@ public class MavenSettingsConfigTest {
                 "  }",
                 "}"), true));
         WorkflowRun run = r.buildAndAssertSuccess(p);
-        r.assertLogNotContains("<password>s3cr3t</password>", run);
-        r.assertLogNotContains("<username>bot</username>", run);
+        r.assertLogNotContains("<password>bot-user-s3cr3t</password>", run);
+        r.assertLogNotContains("<username>bot-user-name</username>", run);
         r.assertLogNotContains("<password>sensitive</password>", run);
         r.assertLogNotContains("<username>admin</username>", run);
         r.assertLogContains("<password>****</password>", run);
         r.assertLogContains("<username>****</username>", run);
         // Missing credentials. Currently treated as nonfatal:
-        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot", "s3cr3t"));
+        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
         SystemCredentialsProvider.getInstance().getCredentials().set(1, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds2", "", "admin", "sensitive"));
         WorkflowRun b2 = r.buildAndAssertSuccess(p);
         r.assertLogContains("Could not find credentials [creds] for p #2", b2);
@@ -141,8 +141,8 @@ public class MavenSettingsConfigTest {
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 String settings = build.getWorkspace().child(build.getEnvironment(listener).get("SETTINGS")).readToString();
                 listener.getLogger().println(settings);
-                assertThat(settings, containsString("<password>s3cr3t</password>"));
-                assertThat(settings, containsString("<username>bot</username>"));
+                assertThat(settings, containsString("<password>bot-user-s3cr3t</password>"));
+                assertThat(settings, containsString("<username>bot-user-name</username>"));
 
                 
                 settings = build.getWorkspace().child(build.getEnvironment(listener).get("GLOBAL_SETTINGS")).readToString();
@@ -154,8 +154,8 @@ public class MavenSettingsConfigTest {
         });
         p.setAssignedNode(slave);
         FreeStyleBuild run = r.buildAndAssertSuccess(p);
-        r.assertLogNotContains("<password>s3cr3t</password>", run);
-        r.assertLogNotContains("<username>bot</username>", run);
+        r.assertLogNotContains("<password>bot-user-s3cr3t</password>", run);
+        r.assertLogNotContains("<username>bot-user-name</username>", run);
         r.assertLogNotContains("<password>sensitive</password>", run);
         r.assertLogNotContains("<username>admin</username>", run);
         r.assertLogContains("<password>****</password>", run);

--- a/src/test/java/org/jenkinsci/plugins/configfiles/properties/PropertiesConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/properties/PropertiesConfigTest.java
@@ -27,7 +27,7 @@ public class PropertiesConfigTest {
     @Test
     public void withCredentials() throws Exception {
         // Smokes with full replace:
-        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "creds", "", "bot", "s3cr3t"));
+        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
         GlobalConfigFiles.get().save(new PropertiesConfig("gradle", "gradle", "", "myprop=", true, Collections.singletonList(new PropertiesCredentialMapping("myprop", "creds"))));
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
@@ -37,7 +37,7 @@ public class PropertiesConfigTest {
                   "                                 variable: 'SETTINGS')]) {",
                   "    String content = readFile(env.SETTINGS)",
                   "    if (currentBuild.id == 1) { // only the first build will have the secret" ,
-                  "      assert content.contains('myprop=s3cr3t')",
+                  "      assert content.contains('myprop=bot-user-s3cr3t')",
                   "    }",
                   "    echo content",
                   "  }",
@@ -45,9 +45,9 @@ public class PropertiesConfigTest {
                 true));
         WorkflowRun b1 = r.buildAndAssertSuccess(p);
         r.assertLogContains("myprop=****", b1);
-        r.assertLogNotContains("myprop=s3cr3t", b1);
+        r.assertLogNotContains("myprop=bot-user-s3cr3t", b1);
         // Missing credentials. Currently treated as nonfatal:
-        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot", "s3cr3t"));
+        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
         WorkflowRun b2 = r.buildAndAssertSuccess(p);
         r.assertLogContains("Could not find credentials [creds] for p #2", b2);
         r.assertLogContains("myprop="+System.lineSeparator(), b2);

--- a/src/test/java/org/jenkinsci/plugins/configfiles/properties/security/CredentialsHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/properties/security/CredentialsHelperTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class CredentialsHelperTest {
 
-    private final static String PWD = "s3cr3t";
+    private final static String PWD = "bot-user-s3cr3t";
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
@@ -22,7 +22,7 @@ public class CredentialsHelperTest {
     @Test
     public void testPropertiesIsReplacedWhenReplaceTrue() throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot", PWD));
+        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
         final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
@@ -34,7 +34,7 @@ public class CredentialsHelperTest {
     @Test
     public void testPropertiesIsNotReplacedWhenReplaceFalse() throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot", PWD));
+        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
         final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
@@ -46,7 +46,7 @@ public class CredentialsHelperTest {
     @Test
     public void testPropertiesIsAddedWhenReplaceTrue() throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot", PWD));
+        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
         final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
@@ -58,7 +58,7 @@ public class CredentialsHelperTest {
     @Test
     public void testPropertiesIsAddedWhenReplaceFalse() throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot", PWD));
+        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
         final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 


### PR DESCRIPTION
## Adjust credentials masking tests for base64 masking improvement

Credentials masking now includes masking of base64 credentials.  The tests were using a very short user name, "bot".  The base64 encoding of that short user name matches with other log content and causes the tests to fail.

Use a longer user name and a longer password in the test so that spurious matches are much less likely.

### Testing done

Confirmed the test fails when I run without b36d0a7623206ffaf2f7dd4d4850414d308cd014

`mvn clean -Dtest=MavenSettingsConfigTest verify`

Confirmed that tests pass when I include b36d0a7623206ffaf2f7dd4d4850414d308cd014

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
