### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
     </properties>
 
@@ -55,8 +55,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2483.v3b_22f030990a_</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2705.vf5c48c31285b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
-            <version>636.v55f1275c7b_27</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/Security2203Test.java
@@ -27,7 +27,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Map;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
@@ -29,7 +29,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.ToolInstallations;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collections;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/common/CleanTempFilesRunListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/common/CleanTempFilesRunListenerTest.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.configfiles.common;
 
 import java.util.Arrays;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFilesManagement;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -32,7 +32,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.ToolInstallations;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
@@ -23,7 +23,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.ToolInstallations;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import static org.junit.Assert.assertNotSame;
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -22,7 +22,7 @@ import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 
 public class SettingsEnvVarTest {


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.