### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.configfiles.buildwrapper;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.Util;
@@ -49,6 +50,7 @@ import java.io.Serializable;
  */
 public class ManagedFile extends ConfigFile implements ExtensionPoint, Describable<ManagedFile>, Serializable {
 
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String variable;
 
     /**


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

[Plugin pom 4.77](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.77) needs this change to resolve new spotbugs warnings that will be reported by spotbugs 4.8.3 and later.

Can skip the changelog, since this is not visible to users.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

Confirmed that spotbugs is silent with plugin pom 4.77 after this change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
