### PR TITLE
table  enhancement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>script-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <scope>test</scope>

--- a/src/main/resources/lib/configfiles/configfiles.jelly
+++ b/src/main/resources/lib/configfiles/configfiles.jelly
@@ -26,56 +26,61 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:cf="/lib/configfiles">
 
+    <st:adjunct includes="org.jenkinsci.plugins.configfiles.styles"/>
     <j:set var="groupedConfigs" value="${attrs.groupedConfigs}"/>
 
     <div class="excerpt">
 
-        <j:forEach var="pEntry" items="${groupedConfigs}">
-            <p/>
-            <p/>
-            <table class="pane">
-                <tr valign="center" style="border-top: 0px;">
-                    <td class="pane-header" colspan="3">
-                        <i>
+        <table class="jenkins-table cfp-table">
+            <j:forEach var="pEntry" items="${groupedConfigs}">
+                <tbody>
+                    <tr class="cfp-table__section-header cfp-table__section-header--title">
+                        <td colspan="6" >
                             ${pEntry.key.displayName}
-                        </i>
-                    </td>
-                </tr>
-                <j:forEach var="t" items="${pEntry.value}">
-                    <tr valign="center" style="border-top: thin inset darkgray">
-                        <td width="32">
-                            <a href="editConfig?id=${t.id}">
-                                <l:icon title="${%edit script} ${t.name}"
-                                     class="icon-notepad icon-md"/>
-                            </a>
-                            <j:out value=" "/>
-                            <l:confirmationLink href="removeConfig?id=${t.id}" post="true" message="Sure you want to delete [${t.name}]?">
-                                <l:icon title="${%remove script} ${t.name}"
-                                     class="icon-edit-delete icon-md"/>
-                            </l:confirmationLink>
                         </td>
-                        <td>
-                            <i>
+                    </tr>
+                    <tr class="cfp-table__section-header cfp-table__section-header--fields">
+                        <td class="jenkins-table__cell--tight cfp-table__icon">
+                            ${%E}
+                        </td>
+                        <td class="jenkins-table__cell--tight cfp-table__icon">
+                            ${%D}
+                        </td>
+                        <td>${%Name}</td>
+                        <td>${%ID}</td>
+                        <td>${%Comment}</td>
+                        <td>${%Content Type}</td>
+                    </tr>
+                    <j:forEach var="t" items="${pEntry.value}">
+                        <tr>
+                            <td class="jenkins-table__cell--tight cfp-table__icon">
+                                <a href="editConfig?id=${t.id}">
+                                    <l:icon tooltip="${%Edit script} ${t.name}" src="symbol-create-outline plugin-ionicons-api"
+                                         class="icon-md"/>
+                                </a>
+                            </td>
+                            <td class="jenkins-table__cell--tight cfp-table__icon">
+                                <l:confirmationLink href="removeConfig?id=${t.id}" post="true" message="Sure you want to delete [${t.name}]?">
+                                    <l:icon tooltip="${%Remove script} ${t.name}" src="symbol-trash-outline plugin-ionicons-api"
+                                            class="icon-md"/>
+                                </l:confirmationLink>
+                            </td>
+                            <td>
                                 ${t.name}
-                            </i>
-                        </td>
-                        <td>
-                            <code>
+                            </td>
+                            <td>
                                 ${t.id}
-                            </code>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            ${t.contentType}
-                        </td>
-                        <td>
-                            ${t.comment}
-                        </td>
-                        <td></td>
-                    </tr>
-                </j:forEach>
-            </table>
-        </j:forEach>
+                            </td>
+                            <td>
+                                ${t.comment}
+                            </td>
+                            <td>
+                                ${t.contentType}
+                            </td>
+                        </tr>
+                    </j:forEach>
+                </tbody>
+            </j:forEach>
+        </table>
     </div>
 </j:jelly>

--- a/src/main/resources/lib/configfiles/selectprovider.jelly
+++ b/src/main/resources/lib/configfiles/selectprovider.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:set var="providers" value="${attrs.providers}" />
 
+    <st:adjunct includes="org.jenkinsci.plugins.configfiles.styles"/>
     <f:form name="addConfig" method="post" action="addConfig">
         <j:if test="${error != null}">
             <j:out value="${error.renderHtml()}" />

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/selectprovider.jelly
@@ -28,18 +28,6 @@ THE SOFTWARE.
 	<l:layout title="${%filetype}" norefresh="true">
 		<cf:sitepanel />
 
-		<!-- TODO Remove when Jenkins LTS release is no longer supported by update center -->
-		<style>
-			.jenkins-radio__label {
-				margin-left: 5px;
-				font-weight: 600;
-			}
-			.jenkins-radio__description {
-				margin: 4px 0 10px 21px;
-				color: var(--text-color-secondary);
-			}
-		</style>
-
 		<l:main-panel>
 			<div class="jenkins-app-bar">
 				<div class="jenkins-app-bar__content">

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/styles.css
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/styles.css
@@ -1,0 +1,34 @@
+.cfp-table {
+  width: auto;
+}
+
+.cfp-table__icon {
+  text-align: center!important;
+  width: 3rem!important;
+}
+
+.cfp-table__section-header > td {
+  background-color: color-mix(in srgb, var(--medium-grey) 20%, var(--light-grey))!important;
+  height: unset!important;
+  font-weight: 600!important;
+  padding-top: 0!important;
+  padding-bottom: 0!important;
+}
+
+.cfp-table > tbody:not(:first-of-type):before {
+  content: "";
+  display: block;
+  height: 20px;
+}
+
+.cfp-table__section-header--title > td {
+  padding: 0 .5rem!important;
+}
+
+.cfp-table__section-header--fields > td:not(.cfp-table__icon) {
+  padding-left: 1.6rem!important;
+}
+
+.jenkins-radio__label {
+  font-weight: 600;
+}


### PR DESCRIPTION
having a separate table for each config file type has the problem that the the column width are different for each type. Also the comment is written in a separate line
This change shows everything in a single table with a tbody for each type. The types are separated by some space and each type has a header with title and column description. Each file is on one line. Styling is moved to a dedicated css file.

remove inline style

<!-- Please describe your pull request here. -->

Before:
![image](https://github.com/jenkinsci/config-file-provider-plugin/assets/17767050/81cb4e79-4156-4765-843e-4ec90fd18ab8)

After: 
![image](https://github.com/jenkinsci/config-file-provider-plugin/assets/17767050/5dc69d84-9d17-443e-b809-c733af0650c4)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
