### PR TITLE
[JENKINS-41289] use readOnlyMode to include edit-config in show-config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile.java
@@ -113,7 +113,7 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
         public ListBoxModel doFillFileIdItems(@AncestorInPath ItemGroup context, @AncestorInPath Item project, @AncestorInPath AccessControlled ac) {
             // You should have permission to configure your project in order to get the available managed files
             if (project != null) {
-                project.checkPermission(Item.CONFIGURE);
+                project.checkAnyPermission(Item.CONFIGURE, Item.EXTENDED_READ);
             } else {
                 ac.checkPermission(Item.CREATE); // This to get the first parent to validate the authorization (Folder, View or Jenkins)
             }
@@ -138,7 +138,7 @@ public class ManagedFile extends ConfigFile implements ExtensionPoint, Describab
             // You should have permission to configure your project in order to check whether the selected file id is
             // allowed to you
             if (context != null) {
-                context.checkPermission(Item.CONFIGURE);
+                context.checkAnyPermission(Item.CONFIGURE, Item.EXTENDED_READ);
             } else {
                 ac.checkPermission(Item.CREATE);
             }

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/edit-config.jelly
@@ -24,13 +24,12 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
 
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/edit.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/edit.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
 			</div>
 
 			<f:form method="post" action="saveConfig">
-			   <f:section title="${%The configuration}" name="config">
+			   <f:section title="${config.descriptor.displayName}" name="config">
 			   		<input type="hidden" name="stapler-class" value="${config.class.name}" />
 			   		<j:choose>
 			          <j:when test="${config.class.name == 'org.jenkinsci.lib.configprovider.model.Config'}">

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show-config.jelly
@@ -8,19 +8,7 @@
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesUI/show.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 		<l:main-panel>
 	
 			<f:form method="" action="">
-				<f:section title="${%Script details}" name="config">
+				<f:section title="${config.descriptor.displayName}" name="config">
 					<j:choose>
 						<j:when test="${config.class.name == 'org.jenkinsci.lib.configprovider.model.Config'}">
 							<st:include page="show-config.jelly" from="${instance}" />

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/builder/ConfigFileBuildStep/config.jelly
@@ -10,7 +10,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 	<f:entry title="${%Managed Files}">
-		<f:repeatableProperty field="managedFiles"  minimum="1" noAddButton="true">
+		<f:repeatableProperty field="managedFiles"  minimum="1">
+			<j:if test="${!readOnlyMode}">
+				<f:repeatableDeleteButton value="${attrs.deleteCaption}" />
+			</j:if>
 		</f:repeatableProperty>
 	</f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapper/config.jelly
@@ -10,7 +10,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 	<f:entry title="${%Managed Files}">
-		<f:repeatableProperty field="managedFiles"  minimum="1" noAddButton="true">
+		<f:repeatableProperty field="managedFiles"  minimum="1">
+			<j:if test="${!readOnlyMode}">
+				<f:repeatableDeleteButton value="${attrs.deleteCaption}" />
+			</j:if>
 		</f:repeatableProperty>
     </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/buildwrapper/ManagedFile/config.jelly
@@ -24,12 +24,4 @@
         <f:entry>
             <f:checkbox title="${%Replace Tokens}" field="replaceTokens" checked="${it.replaceTokens}"/>
         </f:entry>
-
-    <f:entry>
-        <div align="right">
-            <input type="button" value="${%Add file}" class="repeatable-add show-if-last" onclick="fp_initAllDetailLinks();"/>
-            <input type="button" value="${%Delete}" class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
-        </div>
-    </f:entry>
-
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/edit-config.jelly
@@ -24,17 +24,18 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-					<j:set var="instance" value="${config}"/>
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Tokenized Credentials}">
-						<f:repeatableProperty field="customizedCredentialMappings" />
-					</f:entry>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="instance" value="${config}"/>
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
+  <f:entry title="${%Tokenized Credentials}">
+    <f:repeatableProperty field="customizedCredentialMappings" noAddButton="${readOnlyMode}">
+      <j:if test="${not readOnlyMode}">
+        <f:repeatableDeleteButton/>
+      </j:if>
+    </f:repeatableProperty>
+  </f:entry>
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/CustomConfig/show-config.jelly
@@ -8,24 +8,7 @@
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<j:set var="descriptor" value="${config.descriptor}"/>
-	<j:set var="instance" value="${config}"/>
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Tokenized Credentials}" field="customizedCredentialMappings">
-		<f:repeatableProperty field="customizedCredentialMappings" noAddButton="true" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/custom/security/CustomizedCredentialMapping/config.jelly
@@ -33,10 +33,4 @@ THE SOFTWARE.
          <f:entry title="${%Credentials}" field="credentialsId" >
              <c:select />
          </f:entry>
-
-         <f:entry title="" >
-            <div align="right">
-                <f:repeatableDeleteButton />
-             </div>
-         </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/groovy/GroovyScript/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/groovy/GroovyScript/edit-config.jelly
@@ -24,13 +24,10 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/groovy/GroovyScript/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/groovy/GroovyScript/show-config.jelly
@@ -9,18 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/edit-config.jelly
@@ -24,13 +24,10 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/json/JsonConfig/show-config.jelly
@@ -9,18 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/edit-config.jelly
@@ -24,23 +24,27 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-			<j:set var="instance" value="${config}"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+         xmlns:f="/lib/form">
+  <j:set var="instance" value="${config}"/>
 
-            <j:set var="descriptor" value="${config.descriptor}"/>
-            <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
 
-            <f:entry>
-                <f:checkbox title="${%Replace All}" field="isReplaceAll" default="true" value="${config.isReplaceAll}"/>
-            </f:entry>
+  <f:entry>
+    <f:checkbox title="${%Replace All}" field="isReplaceAll" default="true" value="${config.isReplaceAll}"/>
+  </f:entry>
 
-			<f:entry title="${%Server Credentials}" field="serverCredentialMappings">
-                  <f:repeatableProperty field="serverCredentialMappings" />
-			</f:entry>
-			
-                     
-                  <f:entry title="${%Content}">
-                      <f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-                  </f:entry>
+  <f:entry title="${%Server Credentials}" field="serverCredentialMappings">
+    <f:repeatableProperty field="serverCredentialMappings" noAddButton="${readOnlyMode}">
+      <j:if test="${not readOnlyMode}">
+        <f:repeatableDeleteButton/>
+      </j:if>
+    </f:repeatableProperty>
+  </f:entry>
+
+
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/GlobalMavenSettingsConfig/show-config.jelly
@@ -9,24 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <j:set var="descriptor" value="${config.descriptor}"/>
-    <j:set var="instance" value="${config}"/>
-    
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-    <f:entry>
-        <f:checkbox title="${%Replace All}" description="Replace all servers, even ones not found in provided credentials" name="config.replaceAll" value="${config.isReplaceAll}"/>
-    </f:entry>
-    <f:entry title="${%Server Credentials}" field="serverCredentialMappings">
-        <f:repeatableProperty field="serverCredentialMappings" noAddButton="true" />
-    </f:entry>	
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+  <j:set var="readOnlyMode" value="true"/>
+  <st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/edit-config.jelly
@@ -22,29 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" >
-			<j:set var="instance" value="${config}"/>
-	   		<p>
-	   		 ${%description}
-	   		</p>
+  <j:set var="instance" value="${config}"/>
+  <p>
+    ${%description}
+  </p>
 
-            <j:set var="descriptor" value="${config.descriptor}"/>
-            <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
 
-            <f:entry>
-                <f:checkbox title="${%Replace All}" field="isReplaceAll" default="true" value="${config.isReplaceAll}"/>
-            </f:entry>
+  <f:entry>
+    <f:checkbox title="${%Replace All}" field="isReplaceAll" default="true" value="${config.isReplaceAll}"/>
+  </f:entry>
 
-			<f:entry title="${%Server Credentials}">
-                  <f:repeatableProperty field="serverCredentialMappings" />
-			</f:entry>
-                     
-            <f:entry title="${%Content}">
-                <f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-            </f:entry>
+  <f:entry title="${%Server Credentials}">
+    <f:repeatableProperty field="serverCredentialMappings" noAddButton="${readOnlyMode}">
+      <j:if test="${not readOnlyMode}">
+        <f:repeatableDeleteButton />
+      </j:if>
+    </f:repeatableProperty>
+  </f:entry>
+
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}" />
+  </f:entry>
 </j:jelly>
 
 

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfig/show-config.jelly
@@ -9,24 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <j:set var="descriptor" value="${config.descriptor}"/>
-    <j:set var="instance" value="${config}"/>
-    
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-    <f:entry>
-        <f:checkbox title="${%Replace All}" description="Replace all servers, even ones not found in provided credentials" name="config.replaceAll" value="${config.isReplaceAll}"/>
-    </f:entry>
-    <f:entry title="${%Server Credentials}" field="serverCredentialMappings">
-        <f:repeatableProperty field="serverCredentialMappings" noAddButton="true" />
-    </f:entry>	
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+  <j:set var="readOnlyMode" value="true"/>
+  <st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig/edit-config.jelly
@@ -24,13 +24,10 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/MavenToolchainsConfig/show-config.jelly
@@ -9,18 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping/config.jelly
@@ -34,13 +34,6 @@ THE SOFTWARE.
          <f:entry title="${%Credentials}" field="credentialsId" >
              <c:select />
          </f:entry>
-         
-         <f:entry title="" >
-            <div align="right">
-                <f:repeatableDeleteButton />
-             </div>
-         </f:entry>
-         
     </div>
 </j:jelly>
 

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/properties/PropertiesConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/properties/PropertiesConfig/edit-config.jelly
@@ -22,27 +22,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" >
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="instance" value="${config}"/>
+  <p>${%description}</p>
 
-    <j:set var="instance" value="${config}"/>
-    <p>${%description}</p>
+  <j:set var="descriptor" value="${config.descriptor}"/>
+  <st:include page="id-name-and-comment" class="${descriptor.clazz}"/>
 
-    <j:set var="descriptor" value="${config.descriptor}"/>
-    <st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+  <f:entry title="${%Replace All}" field="isReplaceAll">
+    <f:checkbox default="true" value="${config.isReplaceAll}"/>
+  </f:entry>
 
-    <f:entry title="${%Replace All}" field="isReplaceAll">
-        <f:checkbox default="true" value="${config.isReplaceAll}"/>
-    </f:entry>
+  <f:entry title="${%Properties Credentials}">
+    <f:repeatableProperty field="propertiesCredentialMappings" noAddButton="${readOnlyMode}">
+      <j:if test="${not readOnlyMode}">
+        <f:repeatableDeleteButton/>
+      </j:if>
+    </f:repeatableProperty>
+  </f:entry>
 
-    <f:entry title="${%Properties Credentials}">
-        <f:repeatableProperty field="propertiesCredentialMappings" />
-    </f:entry>
-
-    <f:entry title="${%Content}">
-        <f:textarea id="config.content" name="config.content" value="${config.content}" />
-    </f:entry>
+  <f:entry title="${%Content}">
+    <f:textarea id="config.content" name="config.content" value="${config.content}"/>
+  </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/properties/PropertiesConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/properties/PropertiesConfig/show-config.jelly
@@ -8,29 +8,7 @@
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <j:set var="descriptor" value="${config.descriptor}"/>
-    <j:set var="instance" value="${config}"/>
-
-    <f:entry title="${%Name}">
-        <f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-    </f:entry>
-
-    <f:entry title="${%Comment}">
-        <f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-    </f:entry>
-
-    <f:entry title="${%Replace All}" description="Replace all properties, even ones not found in provided credentials">
-        <f:checkbox name="config.replaceAll" value="${config.isReplaceAll}"/>
-    </f:entry>
-
-    <f:entry title="${%Properties Credentials}" field="propertiesCredentialMappings">
-        <f:repeatableProperty field="propertiesCredentialMappings" noAddButton="true" />
-    </f:entry>
-
-    <f:entry title="${%Content}">
-        <f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-    </f:entry>
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <j:set var="readOnlyMode" value="true"/>
+  <st:include page="edit-config" it="${config}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/properties/security/PropertiesCredentialMapping/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/properties/security/PropertiesCredentialMapping/config.jelly
@@ -32,14 +32,7 @@ THE SOFTWARE.
          </f:entry>
 
          <f:entry title="${%Credentials}" field="credentialsId" >
-             <c:select />
+             <c:select/>
          </f:entry>
-
-         <f:entry title="" >
-            <div align="right">
-                <f:repeatableDeleteButton />
-             </div>
-         </f:entry>
-
     </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/xml/XmlConfig/edit-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/xml/XmlConfig/edit-config.jelly
@@ -24,13 +24,10 @@ THE SOFTWARE.
 
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-					<j:set var="descriptor" value="${config.descriptor}"/>
-					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
-					<f:entry title="${%Content}">
-						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
-					</f:entry>
-					
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+	<j:set var="descriptor" value="${config.descriptor}"/>
+	<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+	<f:entry title="${%Content}">
+		<f:textarea id="config.content" name="config.content" value="${config.content}" />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/xml/XmlConfig/show-config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/xml/XmlConfig/show-config.jelly
@@ -9,18 +9,6 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-	<f:entry title="${%ID}">
-		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
-	</f:entry>
-	<f:entry title="${%Name}">
-		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
-	</f:entry>
-	<f:entry title="${%Comment}">
-		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
-	</f:entry>
-	<f:entry title="${%Content}">
-		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
-	</f:entry>
-
+	<j:set var="readOnlyMode" value="true"/>
+	<st:include page="edit-config" it="${config}"/>
 </j:jelly>


### PR DESCRIPTION
Setting var readOnlyMode in jelly will basically disable all inputs, buttons, selects. So in the show-config.jelly files we can just set this var and the include the edit-config. So we no longer need to double maintain the fields.
For those configs that add credentials check the readOnlyMode variable and disable the delete and add buttons accordingly

On order to view a job configuration when one has extended read but no configure it must be avoided that the permissions checks in doCheck and doFill methods check for configure only, they should also allow EXTENDED_READ.


### Testing done
Interactive testing
create for each type a config, when credentials are there add and delete buttons are still there and all fields are editable
create freestyle job and add a buildwrapper to provide credentials, for each config type go to the view details link, all fields are readonly and there are no buttons to add/remove credentials.
(note that the email ext plugin provides 2 config file types but misses to provide show-config.jelly files, thus the view details link leads to broken pages, this problem existed before)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
