### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.5</version>
+        <version>5.6</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.6</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
@@ -36,9 +36,6 @@
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
         <!-- Needed to use Jenkins.MANAGE -->
         <useBeta>true</useBeta>
-
-        <!-- TODO removes once integrated into parent-pom -->
-        <jenkins-test-harness.version>2391.v9b_3e2d3351a_2</jenkins-test-harness.version>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
         <!-- Needed to use Jenkins.MANAGE -->
         <useBeta>true</useBeta>
+
+        <!-- TODO removes once integrated into parent-pom -->
+        <jenkins-test-harness.version>2391.v9b_3e2d3351a_2</jenkins-test-harness.version>
     </properties>
 
     <developers>

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFileStoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFileStoreTest.java
@@ -1,60 +1,60 @@
 package org.jenkinsci.plugins.configfiles;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.hamcrest.Matchers;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Created by domi on 18/01/17.
  */
-public class ConfigFileStoreTest {
+@WithJenkins
+class ConfigFileStoreTest {
 
     private static final String CONFIG_ID = "myid";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void testSaveGlobalConfigFiles() {
-        GlobalConfigFiles store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
-        Assert.assertTrue(store.getConfigs().isEmpty());
+    void testSaveGlobalConfigFiles(JenkinsRule j) {
+        GlobalConfigFiles store =
+                j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        assertTrue(store.getConfigs().isEmpty());
 
         CustomConfig config = new CustomConfig(CONFIG_ID, "name", "comment", "content");
         store.save(config);
 
-        Assert.assertEquals(1, store.getConfigs().size());
+        assertEquals(1, store.getConfigs().size());
         Config savedConfig = store.getConfigs().iterator().next();
-        Assert.assertEquals("name", savedConfig.name);
-        Assert.assertEquals("comment", savedConfig.comment);
-        Assert.assertEquals("content", savedConfig.content);
+        assertEquals("name", savedConfig.name);
+        assertEquals("comment", savedConfig.comment);
+        assertEquals("content", savedConfig.content);
 
         CustomConfig anotherConfig = new CustomConfig("anotherid", "name", "comment", "content");
         store.save(anotherConfig);
 
-        Assert.assertEquals(2, store.getConfigs().size());
+        assertEquals(2, store.getConfigs().size());
 
         // Update config. Check the correct config is updated with proper values
         config = new CustomConfig(CONFIG_ID, "new name", "new comment", "new content");
         store.save(config);
 
-        Assert.assertEquals(2, store.getConfigs().size());
+        assertEquals(2, store.getConfigs().size());
         savedConfig = store.getById(CONFIG_ID);
-        Assert.assertEquals("new name", savedConfig.name);
-        Assert.assertEquals("new comment", savedConfig.comment);
-        Assert.assertEquals("new content", savedConfig.content);
+        assertEquals("new name", savedConfig.name);
+        assertEquals("new comment", savedConfig.comment);
+        assertEquals("new content", savedConfig.content);
 
         // Remove config. Check the correct one is removed
         store.remove(savedConfig.id);
-        Assert.assertEquals(1, store.getConfigs().size());
-        Assert.assertThat(store.getById(anotherConfig.id), Matchers.is(anotherConfig));
-        Assert.assertNull(store.getById(savedConfig.id));
+        assertEquals(1, store.getConfigs().size());
+        assertThat(store.getById(anotherConfig.id), Matchers.is(anotherConfig));
+        assertNull(store.getById(savedConfig.id));
 
         store.remove(anotherConfig.id);
-        Assert.assertEquals(0, store.getConfigs().size());
+        assertEquals(0, store.getConfigs().size());
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesSEC1253Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesSEC1253Test.java
@@ -1,44 +1,44 @@
 package org.jenkinsci.plugins.configfiles;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import hudson.util.VersionNumber;
+import java.util.concurrent.atomic.AtomicReference;
 import org.htmlunit.html.HtmlAnchor;
-import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlInput;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlRadioButtonInput;
-import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
-public class ConfigFilesSEC1253Test {
+@WithJenkins
+class ConfigFilesSEC1253Test {
 
     private static final String CONFIG_ID = "ConfigFilesTestId";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
     @Issue("SECURITY-1253")
-    public void regularCaseStillWorking() throws Exception {
-        GlobalConfigFiles store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+    void regularCaseStillWorking(JenkinsRule j) throws Exception {
+        GlobalConfigFiles store =
+                j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         assertNotNull(store);
         assertThat(store.getConfigs(), empty());
 
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage createConfig = wc.goTo("configfiles/selectProvider");
-        HtmlRadioButtonInput groovyRadioButton = createConfig.getDocumentElement().getOneHtmlElementByAttribute("input", "value", "org.jenkinsci.plugins.configfiles.groovy.GroovyScript");
+        HtmlRadioButtonInput groovyRadioButton = createConfig
+                .getDocumentElement()
+                .getOneHtmlElementByAttribute(
+                        "input", "value", "org.jenkinsci.plugins.configfiles.groovy.GroovyScript");
         groovyRadioButton.click();
         HtmlForm addConfigForm = createConfig.getFormByName("addConfig");
 
@@ -58,7 +58,9 @@ public class ConfigFilesSEC1253Test {
         assertThat(store.getConfigs(), hasSize(1));
 
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        HtmlAnchor removeAnchor = configFiles
+                .getDocumentElement()
+                .getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
 
         if (j.jenkins.getVersion().isOlderThan(new VersionNumber("2.415"))) {
             AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);
@@ -79,8 +81,9 @@ public class ConfigFilesSEC1253Test {
 
     @Test
     @Issue("SECURITY-1253")
-    public void xssPrevention() throws Exception {
-        GlobalConfigFiles store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+    void xssPrevention(JenkinsRule j) throws Exception {
+        GlobalConfigFiles store =
+                j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         assertNotNull(store);
         assertThat(store.getConfigs(), empty());
 
@@ -92,12 +95,12 @@ public class ConfigFilesSEC1253Test {
         JenkinsRule.WebClient wc = j.createWebClient();
 
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        HtmlAnchor removeAnchor = configFiles
+                .getDocumentElement()
+                .getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
 
         AtomicReference<Boolean> alertCalled = new AtomicReference<>(false);
-        wc.setAlertHandler((page, s) -> {
-            alertCalled.set(true);
-        });
+        wc.setAlertHandler((page, s) -> alertCalled.set(true));
         assertThat(alertCalled.get(), is(false));
         if (j.jenkins.getVersion().isOlderThan(new VersionNumber("2.415"))) {
             AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);

--- a/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/ConfigFilesTest.java
@@ -1,52 +1,49 @@
 package org.jenkinsci.plugins.configfiles;
 
-import hudson.model.Item;
-import hudson.model.ItemGroup;
-import jenkins.model.Jenkins;
-import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
-import org.springframework.security.access.AccessDeniedException;
+import static org.junit.jupiter.api.Assertions.*;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.springframework.security.access.AccessDeniedException;
 
-public class ConfigFilesTest {
+@WithJenkins
+class ConfigFilesTest {
 
     private static final String CONFIG_ID = "ConfigFilesTestId";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void testConfigContextResolver() {
-        GlobalConfigFiles store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
-        Assert.assertTrue(store.getConfigs().isEmpty());
+    void testConfigContextResolver(JenkinsRule j) {
+        GlobalConfigFiles store =
+                j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        assertTrue(store.getConfigs().isEmpty());
 
         CustomConfig config = new CustomConfig(CONFIG_ID, "name", "comment", "content");
         store.save(config);
 
-        try {
-            ConfigFiles.getByIdOrNull(new TestItemGroup(), CONFIG_ID);
-            Assert.fail("should have thrown");
-        } catch(IllegalArgumentException e) {
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ConfigFiles.getByIdOrNull(new TestItemGroup(), CONFIG_ID),
+                "should have thrown");
 
         j.getInstance().getExtensionList(ConfigContextResolver.class).get(TestResolver.class).isActive = true;
 
         Config retrievedConfig = ConfigFiles.getByIdOrNull(new TestItemGroup(), CONFIG_ID);
-        Assert.assertNotNull(retrievedConfig);
+        assertNotNull(retrievedConfig);
     }
 
     @TestExtension
-    public static class TestResolver extends ConfigContextResolver
-    {
+    public static class TestResolver extends ConfigContextResolver {
         private boolean isActive = false;
 
         @Override
@@ -58,8 +55,7 @@ public class ConfigFilesTest {
         }
     }
 
-    private class TestItemGroup implements ItemGroup<Item>
-    {
+    private class TestItemGroup implements ItemGroup<Item> {
         @Override
         public String getFullName() {
             return null;
@@ -97,14 +93,10 @@ public class ConfigFilesTest {
         }
 
         @Override
-        public void onRenamed(Item item, String oldName, String newName) throws IOException {
-
-        }
+        public void onRenamed(Item item, String oldName, String newName) throws IOException {}
 
         @Override
-        public void onDeleted(Item item) throws IOException {
-
-        }
+        public void onDeleted(Item item) throws IOException {}
 
         @Override
         public String getDisplayName() {
@@ -117,8 +109,6 @@ public class ConfigFilesTest {
         }
 
         @Override
-        public void save() throws IOException {
-
-        }
+        public void save() throws IOException {}
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesConfigAsCodeTest.java
@@ -1,60 +1,56 @@
 package org.jenkinsci.plugins.configfiles;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.TreeSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.hamcrest.MatcherAssert;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.TreeSet;
 import org.hamcrest.Matchers;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GlobalConfigFilesConfigAsCodeTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class GlobalConfigFilesConfigAsCodeTest {
 
     @Test
     @ConfiguredWithCode("GlobalConfigFilesConfigAsCodeTest.yaml")
-    public void should_set_config_files() {
+    void should_set_config_files(JenkinsConfiguredWithCodeRule j) {
         final GlobalConfigFiles cfg = GlobalConfigFiles.get();
         final Config custom = cfg.getById("custom-test");
-        Assert.assertNotNull(custom);
-        Assert.assertEquals("dummy content 1", custom.content);
+        assertNotNull(custom);
+        assertEquals("dummy content 1", custom.content);
         final Config json = cfg.getById("json-test");
-        Assert.assertNotNull(json);
-        Assert.assertEquals("{ \"dummydata\": {\"dummyKey\": \"dummyValue\"} }", json.content);
+        assertNotNull(json);
+        assertEquals("{ \"dummydata\": {\"dummyKey\": \"dummyValue\"} }", json.content);
         final Config properties = cfg.getById("properties-test");
-        Assert.assertNotNull(properties);
-        Assert.assertEquals("myPropertyKey=myPropertyVal", properties.content);
+        assertNotNull(properties);
+        assertEquals("myPropertyKey=myPropertyVal", properties.content);
         final Config xml = cfg.getById("xml-test");
-        Assert.assertNotNull(xml);
-        Assert.assertEquals("<root><dummy test=\"abc\"></dummy></root>", xml.content);
+        assertNotNull(xml);
+        assertEquals("<root><dummy test=\"abc\"></dummy></root>", xml.content);
         final MavenSettingsConfig maven = (MavenSettingsConfig) cfg.getById("maven-test");
-        Assert.assertNotNull(maven);
-        Assert.assertFalse(maven.isReplaceAll);
-        Assert.assertEquals("someCredentials", maven.getServerCredentialMappings().get(0).getCredentialsId());
+        assertNotNull(maven);
+        assertFalse(maven.isReplaceAll);
+        assertEquals(
+                "someCredentials", maven.getServerCredentialMappings().get(0).getCredentialsId());
     }
 
     /** @see https://issues.jenkins.io/browse/JENKINS-60498 */
     @Test
-    public void ensure_configs_treeset() {
-        final Config[] testConfigs = {
-            new CustomConfig("1", "name1", "", ""),
-            new CustomConfig("2", "name2", "", "")
-        };
+    void ensure_configs_treeset(JenkinsConfiguredWithCodeRule j) {
+        final Config[] testConfigs = {new CustomConfig("1", "name1", "", ""), new CustomConfig("2", "name2", "", "")};
 
         final GlobalConfigFiles cfg = GlobalConfigFiles.get();
         cfg.setConfigs(Arrays.asList(testConfigs));
 
         final Collection<Config> actualConfigs = cfg.getConfigs();
-        Assert.assertTrue("configs must be a TreeSet", actualConfigs instanceof TreeSet);
-        MatcherAssert.assertThat(actualConfigs, Matchers.containsInAnyOrder(testConfigs));
+        assertInstanceOf(TreeSet.class, actualConfigs, "configs must be a TreeSet");
+        assertThat(actualConfigs, Matchers.containsInAnyOrder(testConfigs));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/GlobalConfigFilesTest.java
@@ -1,23 +1,20 @@
 package org.jenkinsci.plugins.configfiles;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
-
 import org.jenkinsci.lib.configprovider.model.Config;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Test for {@link GlobalConfigFiles} to ensure reading data.
  */
-public class GlobalConfigFilesTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class GlobalConfigFilesTest {
 
     /**
      * Read data produced by Jenkins ver. 2.141 and plugin version 2.18.<br>
@@ -27,8 +24,9 @@ public class GlobalConfigFilesTest {
      */
     @LocalData
     @Test
-    public void verifyLoadWithAnonymousInnerClassComparatorVar1() {
-        ConfigFileStore store = j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+    void verifyLoadWithAnonymousInnerClassComparatorVar1(JenkinsRule j) {
+        ConfigFileStore store =
+                j.getInstance().getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         Collection<Config> configs = store.getConfigs();
         assertThat(configs, hasSize(2));
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/HtmlElementUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/HtmlElementUtil.java
@@ -1,35 +1,33 @@
 package org.jenkinsci.plugins.configfiles;
 
 import java.io.IOException;
-import org.htmlunit.Page;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebClientUtil;
 import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlElement;
 
 public class HtmlElementUtil {
-  public HtmlElementUtil() {
-  }
+    private HtmlElementUtil() {}
 
-  public static void clickDialogOkButton(HtmlElement element, HtmlElement document) throws IOException {
-    if (element != null) {
-      boolean var6 = false;
+    public static void clickDialogOkButton(HtmlElement element, HtmlElement document) throws IOException {
+        if (element != null) {
+            boolean var6 = false;
 
-      try {
-        var6 = true;
-        element.click();
-        var6 = false;
-      } finally {
-        if (var6) {
-          WebClient var4 = element.getPage().getWebClient();
-          WebClientUtil.waitForJSExec(var4);
+            try {
+                var6 = true;
+                element.click();
+                var6 = false;
+            } finally {
+                if (var6) {
+                    WebClient var4 = element.getPage().getWebClient();
+                    WebClientUtil.waitForJSExec(var4);
+                }
+            }
+
+            WebClient webClient = element.getPage().getWebClient();
+            WebClientUtil.waitForJSExec(webClient);
+            HtmlButton confirmButton = document.getOneHtmlElementByAttribute("button", "data-id", "ok");
+            confirmButton.click();
         }
-      }
-
-      WebClient webClient = element.getPage().getWebClient();
-      WebClientUtil.waitForJSExec(webClient);
-      HtmlButton confirmButton = document.getOneHtmlElementByAttribute("button", "data-id", "ok");
-      confirmButton.click();
     }
-  }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/common/CleanTempFilesRunListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/common/CleanTempFilesRunListenerTest.java
@@ -1,67 +1,57 @@
 package org.jenkinsci.plugins.configfiles.common;
 
-import java.util.Arrays;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Cause.UserIdCause;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 import jakarta.inject.Inject;
-
+import java.util.Arrays;
 import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.plugins.configfiles.ConfigFilesManagement;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.builder.ConfigFileBuildStep;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig.CustomConfigProvider;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.model.Cause.UserIdCause;
-
-import static org.junit.Assert.assertEquals;
-
-public class CleanTempFilesRunListenerTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
-    @Rule
-    public BuildWatcher buildWatcher = new BuildWatcher();
+@WithJenkins
+class CleanTempFilesRunListenerTest {
 
     @Inject
     CustomConfigProvider customConfigProvider;
 
-    @Inject
-    ConfigFilesManagement configFilesManagement;
-
     @Test
-    public void cleanTempFilesActionIsTransient() throws Exception {
+    void cleanTempFilesActionIsTransient(JenkinsRule j) throws Exception {
         j.jenkins.getInjector().injectMembers(this);
 
         final FreeStyleProject p = j.createFreeStyleProject("free");
 
-        final Config customFile = createCustomFile("config-id", customConfigProvider, "blah");
+        final Config customFile = createCustomFile(j, "config-id", customConfigProvider, "blah");
         final ManagedFile managedFile = new ManagedFile(customFile.id, "/tmp/blah", null, true);
         p.getBuildersList().add(new ConfigFileBuildStep(Arrays.asList(managedFile)));
 
         p.getBuildersList().add(new AssertOneCleanTempFilesAction());
 
-        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        j.assertBuildStatus(
+                Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
 
         // assert the CleanTempFilesAction is gone
-        assertEquals(0, p.getBuildByNumber(1).getActions(CleanTempFilesAction.class).size());
+        assertEquals(
+                0, p.getBuildByNumber(1).getActions(CleanTempFilesAction.class).size());
     }
 
-    private Config createCustomFile(String configId, CustomConfigProvider provider, String content) {
+    private Config createCustomFile(JenkinsRule j, String configId, CustomConfigProvider provider, String content) {
         Config c1 = provider.newConfig(configId);
         c1 = new CustomConfig(c1.id, c1.name, c1.comment, content);
-        GlobalConfigFiles globalConfigFiles = j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles globalConfigFiles =
+                j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         globalConfigFiles.save(c1);
         return c1;
     }
@@ -74,5 +64,4 @@ public class CleanTempFilesRunListenerTest {
             return true;
         }
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/custom/CustomConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/custom/CustomConfigTest.java
@@ -1,5 +1,19 @@
 package org.jenkinsci.plugins.configfiles.custom;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Cause.UserIdCause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.Builder;
+import hudson.util.Secret;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Collections;
@@ -10,52 +24,44 @@ import org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;
 import org.jenkinsci.plugins.configfiles.custom.security.CustomizedCredentialMapping;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Result;
-import hudson.model.Cause.UserIdCause;
-import hudson.tasks.Builder;
-import hudson.util.Secret;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class CustomConfigTest {
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @TempDir
+    public static File folder;
 
-    @ClassRule
-    public static TemporaryFolder folder = new TemporaryFolder();
+    @Test
+    @Issue("SECURITY-3090")
+    void credentialsAreMaskedInTheConsole(JenkinsRule r) throws Exception {
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "creds", "desc", Secret.fromString("s3cr3t")));
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
-
-    @Test @Issue("SECURITY-3090")
-    public void credentialsAreMaskedInTheConsole() throws Exception {
-        SystemCredentialsProvider.getInstance().getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "creds", "desc", Secret.fromString("s3cr3t")));
-
-        GlobalConfigFiles.get().save(new CustomConfig("my-id", "my-name", "my-comment", "${thecred}", List.of(new CustomizedCredentialMapping("thecred", "creds"))));
+        GlobalConfigFiles.get()
+                .save(new CustomConfig(
+                        "my-id",
+                        "my-name",
+                        "my-comment",
+                        "${thecred}",
+                        List.of(new CustomizedCredentialMapping("thecred", "creds"))));
 
         final FreeStyleProject p = r.createFreeStyleProject("free");
 
-        final ManagedFile mCustom = new ManagedFile("my-id", folder.newFile().toString(), null, true);
+        final ManagedFile mCustom = new ManagedFile(
+                "my-id", File.createTempFile("junit", null, folder).toString(), null, true);
         ConfigFileBuildWrapper bw = new ConfigFileBuildWrapper(Collections.singletonList(mCustom));
         p.getBuildWrappersList().add(bw);
 
         p.getBuildersList().add(new VerifyFileContentBuilder(mCustom.getTargetLocation(), "s3cr3t"));
 
-        FreeStyleBuild build = r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        FreeStyleBuild build = r.assertBuildStatus(
+                Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
         r.assertLogNotContains("s3cr3t", build);
     }
 
@@ -69,11 +75,12 @@ public class CustomConfigTest {
         }
 
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
             final String fileContent = IOUtils.toString(new FileReader(filePath));
             listener.getLogger().println("File contents: ");
             listener.getLogger().println(fileContent);
-            Assert.assertEquals("file content not correct", expectedContent, fileContent);
+            assertEquals(expectedContent, fileContent, "file content not correct");
             return true;
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/folder/FolderConfigFilesTest.java
@@ -1,25 +1,22 @@
 package org.jenkinsci.plugins.configfiles.folder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-
-import java.util.Collection;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import java.util.Collection;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Test for {@link FolderConfigFileProperty} to ensure reading data.
  */
-public class FolderConfigFilesTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class FolderConfigFilesTest {
 
     /**
      * Read data produced by Jenkins ver. 2.141 and plugin version 2.18.<br>
@@ -29,8 +26,10 @@ public class FolderConfigFilesTest {
      */
     @LocalData
     @Test
-    public void verifyLoadWithAnonymousInnerClassComparatorVar1() {
-        ConfigFileStore store = ((Folder) j.jenkins.getItemByFullName("test-folder")).getAction(FolderConfigFileAction.class).getStore();
+    void verifyLoadWithAnonymousInnerClassComparatorVar1(JenkinsRule j) {
+        ConfigFileStore store = ((Folder) j.jenkins.getItemByFullName("test-folder"))
+                .getAction(FolderConfigFileAction.class)
+                .getStore();
         Collection<Config> configs = store.getConfigs();
         assertThat(configs, hasSize(2));
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/MavenSettingsConfigTest.java
@@ -23,99 +23,101 @@
  */
 package org.jenkinsci.plugins.configfiles.maven;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-
-import java.io.IOException;
-import java.text.MessageFormat;
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.model.Computer;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.remoting.Callable;
 import hudson.slaves.DumbSlave;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper;
 import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;
 import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
-import org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.remoting.RoleChecker;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.Rule;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
+@WithJenkins
+class MavenSettingsConfigTest {
 
-public class MavenSettingsConfigTest {
+    private JenkinsRule r;
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
-
-    public void assertNoSecretPatternOnControllerLog(Computer computer) throws IOException {
-        // https://github.com/jenkinsci/credentials-binding-plugin/blob/8c080630bc65ef1eb1183d0e5cc179dc486122c0/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java#L82
-        // brittle however the log is on the agent so LoggerRule will not work here. 
-        assertThat(computer.getLog(), not(containsString("An agent attempted to look up secret patterns from the controller")));
-    }
-
-    private UsernamePasswordCredentialsImpl createCredential(String id, String username, String password) throws Descriptor.FormException {
-        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, id, "", username, password);
+    private UsernamePasswordCredentialsImpl createCredential(String id, String username, String password)
+            throws Descriptor.FormException {
+        UsernamePasswordCredentialsImpl credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, id, "", username, password);
         credentials.setUsernameSecret(true);
         SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
         return credentials;
     }
-    @Before
-    public void before() throws Exception {
-        GlobalConfigFiles.get().save(new MavenSettingsConfig("m2settings", "m2settings", "", "<settings/>", true, 
-                Collections.singletonList(new ServerCredentialMapping("myserver", createCredential("creds", "bot-user-name", "bot-user-s3cr3t").getId()))));
-        GlobalConfigFiles.get().save(new GlobalMavenSettingsConfig("m2GlobalSettings", "m2GlobalSettings", "", "<settings/>", true, 
-                Collections.singletonList(new ServerCredentialMapping("myGlobalServer", createCredential("creds2", "admin", "sensitive").getId()))));
 
+    @BeforeEach
+    void before(JenkinsRule r) throws Exception {
+        this.r = r;
+        GlobalConfigFiles.get()
+                .save(new MavenSettingsConfig(
+                        "m2settings",
+                        "m2settings",
+                        "",
+                        "<settings/>",
+                        true,
+                        Collections.singletonList(new ServerCredentialMapping(
+                                "myserver",
+                                createCredential("creds", "bot-user-name", "bot-user-s3cr3t")
+                                        .getId()))));
+        GlobalConfigFiles.get()
+                .save(new GlobalMavenSettingsConfig(
+                        "m2GlobalSettings",
+                        "m2GlobalSettings",
+                        "",
+                        "<settings/>",
+                        true,
+                        Collections.singletonList(new ServerCredentialMapping(
+                                "myGlobalServer",
+                                createCredential("creds2", "admin", "sensitive").getId()))));
     }
 
-    @Test @Issue("SECURITY-3090")
-    public void withCredentials() throws Exception {
+    @Test
+    @Issue("SECURITY-3090")
+    void withCredentials() throws Exception {
         // Smokes:
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(String.join("\n",
-                "node () {",
-                "  configFileProvider([configFile(fileId: 'm2settings', variable: 'SETTINGS'), configFile(fileId: 'm2GlobalSettings', variable: 'GOBAL_SETTINGS')]) {",
-                "    String settings = readFile(env.SETTINGS)",
-                "    echo settings",
-                "    if (!settings.equals('<settings/>')) {", //Build #2 won't have credentials to assert on
-                "      assert settings.contains('<password>bot-user-s3cr3t</password>')",
-                "      assert settings.contains('<username>bot-user-name</username>')",
-                "    }",
-                "    settings = readFile(env.GOBAL_SETTINGS)",
-                "    echo settings",
-                "    if (!settings.equals('<settings/>')) {", //Build #2 won't have credentials to assert on
-                "      assert settings.contains('<password>sensitive</password>')",
-                "      assert settings.contains('<username>admin</username>')",
-                "    }",
-                "  }",
-                "}"), true));
+        p.setDefinition(new CpsFlowDefinition(
+                String.join(
+                        "\n",
+                        "node () {",
+                        "  configFileProvider([configFile(fileId: 'm2settings', variable: 'SETTINGS'), configFile(fileId: 'm2GlobalSettings', variable: 'GOBAL_SETTINGS')]) {",
+                        "    String settings = readFile(env.SETTINGS)",
+                        "    echo settings",
+                        "    if (!settings.equals('<settings/>')) {", // Build #2 won't have credentials to assert on
+                        "      assert settings.contains('<password>bot-user-s3cr3t</password>')",
+                        "      assert settings.contains('<username>bot-user-name</username>')",
+                        "    }",
+                        "    settings = readFile(env.GOBAL_SETTINGS)",
+                        "    echo settings",
+                        "    if (!settings.equals('<settings/>')) {", // Build #2 won't have credentials to assert on
+                        "      assert settings.contains('<password>sensitive</password>')",
+                        "      assert settings.contains('<username>admin</username>')",
+                        "    }",
+                        "  }",
+                        "}"),
+                true));
         WorkflowRun run = r.buildAndAssertSuccess(p);
         r.assertLogNotContains("<password>bot-user-s3cr3t</password>", run);
         r.assertLogNotContains("<username>bot-user-name</username>", run);
@@ -124,29 +126,47 @@ public class MavenSettingsConfigTest {
         r.assertLogContains("<password>****</password>", run);
         r.assertLogContains("<username>****</username>", run);
         // Missing credentials. Currently treated as nonfatal:
-        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
-        SystemCredentialsProvider.getInstance().getCredentials().set(1, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds2", "", "admin", "sensitive"));
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .set(
+                        0,
+                        new UsernamePasswordCredentialsImpl(
+                                CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .set(
+                        1,
+                        new UsernamePasswordCredentialsImpl(
+                                CredentialsScope.SYSTEM, "creds2", "", "admin", "sensitive"));
         WorkflowRun b2 = r.buildAndAssertSuccess(p);
         r.assertLogContains("Could not find credentials [creds] for p #2", b2);
         r.assertLogNotContains("<password>", b2);
     }
 
-    @Test @Issue("SECURITY-3090")
-    public void freestyleWithCredentials() throws Exception {
+    @Test
+    @Issue("SECURITY-3090")
+    void freestyleWithCredentials() throws Exception {
         DumbSlave slave = r.createOnlineSlave();
 
         FreeStyleProject p = r.createFreeStyleProject();
-        p.getBuildWrappersList().add(new ConfigFileBuildWrapper(List.of(new ManagedFile("m2settings", null, "SETTINGS"), new ManagedFile("m2GlobalSettings", null, "GLOBAL_SETTINGS"))));
+        p.getBuildWrappersList()
+                .add(new ConfigFileBuildWrapper(List.of(
+                        new ManagedFile("m2settings", null, "SETTINGS"),
+                        new ManagedFile("m2GlobalSettings", null, "GLOBAL_SETTINGS"))));
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-                String settings = build.getWorkspace().child(build.getEnvironment(listener).get("SETTINGS")).readToString();
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                String settings = build.getWorkspace()
+                        .child(build.getEnvironment(listener).get("SETTINGS"))
+                        .readToString();
                 listener.getLogger().println(settings);
                 assertThat(settings, containsString("<password>bot-user-s3cr3t</password>"));
                 assertThat(settings, containsString("<username>bot-user-name</username>"));
 
-                
-                settings = build.getWorkspace().child(build.getEnvironment(listener).get("GLOBAL_SETTINGS")).readToString();
+                settings = build.getWorkspace()
+                        .child(build.getEnvironment(listener).get("GLOBAL_SETTINGS"))
+                        .readToString();
                 listener.getLogger().println(settings);
                 assertThat(settings, containsString("<password>sensitive</password>"));
                 assertThat(settings, containsString("<username>admin</username>"));
@@ -162,5 +182,4 @@ public class MavenSettingsConfigTest {
         r.assertLogContains("<password>****</password>", run);
         r.assertLogContains("<username>****</username>", run);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.configfiles.maven.job;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
@@ -15,6 +18,11 @@ import hudson.model.BuildListener;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.Result;
 import hudson.model.TaskListener;
+import jakarta.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
@@ -22,39 +30,26 @@ import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalM
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.ToolInstallations;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import jakarta.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import static org.junit.Assert.assertNotNull;
-
-public class MvnSettingsCredentialsTest {
-
-    @Rule
-    public JenkinsRule                        j = new JenkinsRule();
-
-    @Rule
-    public BuildWatcher                       bw = new BuildWatcher();
+@WithJenkins
+class MvnSettingsCredentialsTest {
 
     @Inject
-    private MavenSettingsConfigProvider       mavenSettingProvider;
+    private MavenSettingsConfigProvider mavenSettingProvider;
 
     @Inject
     private GlobalMavenSettingsConfigProvider globalMavenSettingsConfigProvider;
 
-    @Test @Issue("SECURITY-3090")
-    public void serverCredentialsMustBeInSettingsXmlAtRuntime() throws Exception {
+    @Test
+    @Issue("SECURITY-3090")
+    void serverCredentialsMustBeInSettingsXmlAtRuntime(JenkinsRule j) throws Exception {
         j.jenkins.getInjector().injectMembers(this);
 
         final MavenModuleSet p = j.createProject(MavenModuleSet.class);
@@ -63,35 +58,40 @@ public class MvnSettingsCredentialsTest {
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize");
 
-        final MavenSettingsConfig settings = createSettings(mavenSettingProvider);
+        final MavenSettingsConfig settings = createSettings(j, mavenSettingProvider);
         final MvnSettingsProvider mvnSettingsProvider = new MvnSettingsProvider(settings.id);
         DelegatingMvnSettingsProvider delegator = new DelegatingMvnSettingsProvider(mvnSettingsProvider);
 
-        final GlobalMavenSettingsConfig globalSettings = createGlobalSettings(globalMavenSettingsConfigProvider);
+        final GlobalMavenSettingsConfig globalSettings = createGlobalSettings(j, globalMavenSettingsConfigProvider);
         final MvnGlobalSettingsProvider mvnGlobalSettingsProvider = new MvnGlobalSettingsProvider(globalSettings.id);
-        DelegatingGlobalMvnSettingsProvider delegator2 = new DelegatingGlobalMvnSettingsProvider(mvnGlobalSettingsProvider);
+        DelegatingGlobalMvnSettingsProvider delegator2 =
+                new DelegatingGlobalMvnSettingsProvider(mvnGlobalSettingsProvider);
 
         p.setSettings(delegator);
         p.setGlobalSettings(delegator2);
 
-        //SECURITY-3090
+        // SECURITY-3090
         p.getPostbuilders().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
                 EnvVars environment = build.getEnvironment(listener);
                 String settingsPath = environment.get("MVN_SETTINGS");
-                assertNotNull("There should be an environment var specifying the mvn settings", settingsPath);
+                assertNotNull(settingsPath, "There should be an environment var specifying the mvn settings");
                 String globalSettingsPath = environment.get("MVN_GLOBALSETTINGS");
-                assertNotNull("There should be an environment var specifying the mvn global settings", globalSettingsPath);
+                assertNotNull(
+                        globalSettingsPath, "There should be an environment var specifying the mvn global settings");
                 String settings = build.getWorkspace().child(settingsPath).readToString();
                 listener.getLogger().println("SETTINGS:\n" + settings);
-                String globalSettings = build.getWorkspace().child(globalSettingsPath).readToString();
+                String globalSettings =
+                        build.getWorkspace().child(globalSettingsPath).readToString();
                 listener.getLogger().println("GLOBAL SETTINGS:\n" + globalSettings);
                 return true;
             }
         });
 
-        MavenModuleSetBuild build = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        MavenModuleSetBuild build = j.assertBuildStatus(
+                Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
 
         j.assertLogNotContains("<password>bar</password>", build);
         j.assertLogNotContains("<username>foo</username>", build);
@@ -119,11 +119,10 @@ public class MvnSettingsCredentialsTest {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            Assert.assertTrue("settings must contain username", settingContent.contains("<username>foo</username>"));
-            Assert.assertTrue("settings must contain password", settingContent.contains("<password>bar</password>"));
+            assertTrue(settingContent.contains("<username>foo</username>"), "settings must contain username");
+            assertTrue(settingContent.contains("<password>bar</password>"), "settings must contain password");
             return settingsPath;
         }
-
     }
 
     private static final class DelegatingGlobalMvnSettingsProvider extends MvnGlobalSettingsProvider {
@@ -144,47 +143,61 @@ public class MvnSettingsCredentialsTest {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            Assert.assertTrue("settings must contain username", settingContent.contains("<username>dude</username>"));
-            Assert.assertTrue("settings must contain password", settingContent.contains("<password>dudepwd</password>"));
+            assertTrue(settingContent.contains("<username>dude</username>"), "settings must contain username");
+            assertTrue(settingContent.contains("<password>dudepwd</password>"), "settings must contain password");
             return settingsPath;
         }
     }
 
-    private MavenSettingsConfig createSettings(MavenSettingsConfigProvider provider) throws Exception {
+    private MavenSettingsConfig createSettings(JenkinsRule j, MavenSettingsConfigProvider provider) throws Exception {
 
-        CredentialsStore store = CredentialsProvider.lookupStores(j.getInstance()).iterator().next();
-        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "credid", "dummy desc", "foo", "bar");
+        CredentialsStore store =
+                CredentialsProvider.lookupStores(j.getInstance()).iterator().next();
+        UsernamePasswordCredentialsImpl credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "credid", "dummy desc", "foo", "bar");
         credentials.setUsernameSecret(true);
         store.addCredentials(Domain.global(), credentials);
 
         ServerCredentialMapping mapping = new ServerCredentialMapping("myserver", "credid");
-        List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
+        List<ServerCredentialMapping> mappings = new ArrayList<>();
         mappings.add(mapping);
 
         MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig();
-        MavenSettingsConfig c2 = new MavenSettingsConfig(c1.id + "dummy", c1.name, c1.comment, c1.content, MavenSettingsConfig.isReplaceAllDefault, mappings);
+        MavenSettingsConfig c2 = new MavenSettingsConfig(
+                c1.id + "dummy", c1.name, c1.comment, c1.content, MavenSettingsConfig.isReplaceAllDefault, mappings);
 
-        GlobalConfigFiles globalConfigFiles = j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles globalConfigFiles =
+                j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         globalConfigFiles.save(c2);
 
         return c2;
     }
 
-    private GlobalMavenSettingsConfig createGlobalSettings(GlobalMavenSettingsConfigProvider provider) throws Exception {
+    private GlobalMavenSettingsConfig createGlobalSettings(JenkinsRule j, GlobalMavenSettingsConfigProvider provider)
+            throws Exception {
 
-        CredentialsStore store = CredentialsProvider.lookupStores(j.getInstance()).iterator().next();
-        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "dudecredid", "dummy desc", "dude", "dudepwd");
+        CredentialsStore store =
+                CredentialsProvider.lookupStores(j.getInstance()).iterator().next();
+        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "dudecredid", "dummy desc", "dude", "dudepwd");
         credentials.setUsernameSecret(true);
         store.addCredentials(Domain.global(), credentials);
 
         ServerCredentialMapping mapping = new ServerCredentialMapping("someserver", "dudecredid");
-        List<ServerCredentialMapping> mappings = new ArrayList<ServerCredentialMapping>();
+        List<ServerCredentialMapping> mappings = new ArrayList<>();
         mappings.add(mapping);
 
         GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig();
-        GlobalMavenSettingsConfig c2 = new GlobalMavenSettingsConfig(c1.id + "dummy2", c1.name, c1.comment, c1.content,  GlobalMavenSettingsConfig.isReplaceAllDefault, mappings);
+        GlobalMavenSettingsConfig c2 = new GlobalMavenSettingsConfig(
+                c1.id + "dummy2",
+                c1.name,
+                c1.comment,
+                c1.content,
+                GlobalMavenSettingsConfig.isReplaceAllDefault,
+                mappings);
 
-        GlobalConfigFiles globalConfigFiles = j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles globalConfigFiles =
+                j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         globalConfigFiles.save(c2);
 
         return c2;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.configfiles.maven.job;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import hudson.Launcher;
 import hudson.maven.MavenModuleSet;
 import hudson.model.AbstractBuild;
@@ -7,6 +10,8 @@ import hudson.model.BuildListener;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.Result;
 import hudson.tasks.Builder;
+import jakarta.inject.Inject;
+import java.io.IOException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig;
@@ -15,28 +20,22 @@ import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import jakarta.inject.Inject;
-import java.io.IOException;
-
-public class SettingsEnvVarTest {
-    @Rule
-    public JenkinsRule                        j = new JenkinsRule();
-
+@WithJenkins
+class SettingsEnvVarTest {
     @Inject
-    private MavenSettingsConfigProvider       mavenSettingProvider;
+    private MavenSettingsConfigProvider mavenSettingProvider;
 
     @Inject
     private GlobalMavenSettingsConfigProvider globalMavenSettingsConfigProvider;
 
     @Test
-    public void serverCredentialsMustBeInSettingsXmlAtRuntime() throws Exception {
+    void serverCredentialsMustBeInSettingsXmlAtRuntime(JenkinsRule j) throws Exception {
         j.jenkins.getInjector().injectMembers(this);
 
         final MavenModuleSet p = j.createProject(MavenModuleSet.class);
@@ -45,10 +44,10 @@ public class SettingsEnvVarTest {
         p.setScm(new ExtractResourceSCM(getClass().getResource("/maven3-project.zip")));
         p.setGoals("initialize");
 
-        final MavenSettingsConfig settings = createSettings(mavenSettingProvider);
+        final MavenSettingsConfig settings = createSettings(j, mavenSettingProvider);
         final MvnSettingsProvider mvnSettingsProvider = new MvnSettingsProvider(settings.id);
 
-        final GlobalMavenSettingsConfig globalSettings = createGlobalSettings(globalMavenSettingsConfigProvider);
+        final GlobalMavenSettingsConfig globalSettings = createGlobalSettings(j, globalMavenSettingsConfigProvider);
         final MvnGlobalSettingsProvider mvnGlobalSettingsProvider = new MvnGlobalSettingsProvider(globalSettings.id);
 
         p.setSettings(mvnSettingsProvider);
@@ -56,37 +55,43 @@ public class SettingsEnvVarTest {
 
         p.getPostbuilders().add(new VerifyBuilder());
 
-        j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        j.assertBuildStatus(
+                Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
     }
 
     private static final class VerifyBuilder extends Builder {
 
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
             try {
                 final String userSettings = TokenMacro.expandAll(build, listener, "${ENV, var=\"MVN_SETTINGS\"}");
-                final String globalSettings = TokenMacro.expandAll(build, listener, "${ENV, var=\"MVN_GLOBALSETTINGS\"}");
-                Assert.assertTrue("env variable for user settings is not set", StringUtils.isNotBlank(userSettings));
-                Assert.assertTrue("env variable for global settings is not set", StringUtils.isNotBlank(globalSettings));
+                final String globalSettings =
+                        TokenMacro.expandAll(build, listener, "${ENV, var=\"MVN_GLOBALSETTINGS\"}");
+                assertTrue(StringUtils.isNotBlank(userSettings), "env variable for user settings is not set");
+                assertTrue(StringUtils.isNotBlank(globalSettings), "env variable for global settings is not set");
             } catch (MacroEvaluationException e) {
-                Assert.fail("not able to expand var: " + e.getMessage());
+                fail("not able to expand var: " + e.getMessage());
             }
             return true;
         }
     }
 
-    private MavenSettingsConfig createSettings(MavenSettingsConfigProvider provider) throws Exception {
+    private MavenSettingsConfig createSettings(JenkinsRule j, MavenSettingsConfigProvider provider) throws Exception {
 
         MavenSettingsConfig c1 = (MavenSettingsConfig) provider.newConfig();
-        GlobalConfigFiles globalConfigFiles = j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles globalConfigFiles =
+                j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         globalConfigFiles.save(c1);
         return c1;
     }
 
-    private GlobalMavenSettingsConfig createGlobalSettings(GlobalMavenSettingsConfigProvider provider) throws Exception {
+    private GlobalMavenSettingsConfig createGlobalSettings(JenkinsRule j, GlobalMavenSettingsConfigProvider provider)
+            throws Exception {
 
         GlobalMavenSettingsConfig c1 = (GlobalMavenSettingsConfig) provider.newConfig();
-        GlobalConfigFiles globalConfigFiles = j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles globalConfigFiles =
+                j.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
         globalConfigFiles.save(c1);
         return c1;
     }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/security/CredentialsHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/security/CredentialsHelperTest.java
@@ -1,164 +1,195 @@
-
 package org.jenkinsci.plugins.configfiles.maven.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
-
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+@WithJenkins
+class CredentialsHelperTest {
 
-public class CredentialsHelperTest {
-
-    final static String PWD     = "MY_NEW_PWD";
-    final static String PWD_2   = "{COQLCE6DU6GtcS5P=}";
-    final static int SERVER_COUNT = 5;
-
-    @Rule
-    public JenkinsRule  jenkins = new JenkinsRule();
+    static final String PWD = "MY_NEW_PWD";
+    static final String PWD_2 = "{COQLCE6DU6GtcS5P=}";
+    static final int SERVER_COUNT = 5;
 
     @Test
-    public void testIfServerAuthIsReplacedWithinSettingsXmlWhenReplaceTrue() throws Exception {
+    void testIfServerAuthIsReplacedWithinSettingsXmlWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
 
-        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
-        serverId2Credentials.put("my.server", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
-        serverId2Credentials.put("encoded_pwd", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "*pwd", "some desc2", "dan", PWD_2));
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<>();
+        serverId2Credentials.put(
+                "my.server",
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
+        serverId2Credentials.put(
+                "encoded_pwd",
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "*pwd", "some desc2", "dan", PWD_2));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
 
-        List<String> tempFiles = new ArrayList<String>();
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.TRUE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+        List<String> tempFiles = new ArrayList<>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(
+                settingsContent, Boolean.TRUE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
 
-        Assert.assertTrue("replaced settings.xml must contain new password", replacedContent.contains(PWD));
+        assertTrue(replacedContent.contains(PWD), "replaced settings.xml must contain new password");
 
         // ensure it is still a valid XML document
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(replacedContent)));
+        Document doc = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader(replacedContent)));
         // locate the node(s)
         XPath xpath = XPathFactory.newInstance().newXPath();
         NodeList nodes = (NodeList) xpath.evaluate("/settings/servers/server", doc, XPathConstants.NODESET);
-        // the 'settings_test.xml' actually contains 4 server tags, but we remove all and only inject the ones managed by the plugin
-        Assert.assertEquals("there is not the same number of server tags anymore in the settings.xml", 2, nodes.getLength());
+        // the 'settings_test.xml' actually contains 4 server tags, but we remove all and only inject the ones managed
+        // by the plugin
+        assertEquals(2, nodes.getLength(), "there is not the same number of server tags anymore in the settings.xml");
 
         Node server = (Node) xpath.evaluate("/settings/servers/server[id='my.server']", doc, XPathConstants.NODE);
-        Assert.assertEquals("password is not at the correct location", PWD, xpath.evaluate("password", server));
-        Assert.assertEquals("username is not set correct", "peter", xpath.evaluate("username", server));
+        assertEquals(PWD, xpath.evaluate("password", server), "password is not at the correct location");
+        assertEquals("peter", xpath.evaluate("username", server), "username is not set correct");
 
         Node server2 = (Node) xpath.evaluate("/settings/servers/server[id='encoded_pwd']", doc, XPathConstants.NODE);
-        Assert.assertEquals("password is not set correct", PWD_2, xpath.evaluate("password", server2));
-        Assert.assertEquals("username is not set correct", "dan", xpath.evaluate("username", server2));
-
+        assertEquals(PWD_2, xpath.evaluate("password", server2), "password is not set correct");
+        assertEquals("dan", xpath.evaluate("username", server2), "username is not set correct");
     }
 
     @Test
-    public void testIfServerAuthIsReplacedWithinSettingsXmlWhenReplaceFalse() throws Exception {
+    void testIfServerAuthIsReplacedWithinSettingsXmlWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
 
-        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
-        serverId2Credentials.put("my.server", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
-        serverId2Credentials.put("encoded_pwd", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "*pwd", "some desc2", "dan", PWD_2));
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<>();
+        serverId2Credentials.put(
+                "my.server",
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
+        serverId2Credentials.put(
+                "encoded_pwd",
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "*pwd", "some desc2", "dan", PWD_2));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
-        List<String> tempFiles = new ArrayList<String>();
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        List<String> tempFiles = new ArrayList<>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(
+                settingsContent, Boolean.FALSE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
 
-        Assert.assertTrue("replaced settings.xml must contain new password", replacedContent.contains(PWD));
+        assertTrue(replacedContent.contains(PWD), "replaced settings.xml must contain new password");
 
         // ensure it is still a valid XML document
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(replacedContent)));
+        Document doc = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader(replacedContent)));
         // locate the node(s)
         XPath xpath = XPathFactory.newInstance().newXPath();
         NodeList nodes = (NodeList) xpath.evaluate("/settings/servers/server", doc, XPathConstants.NODESET);
-        // the 'settings_test.xml' actually contains 4 server tags, but we remove all and only inject the ones managed by the plugin
-        Assert.assertEquals("there is not the same number of server tags anymore in the settings.xml", SERVER_COUNT, nodes.getLength());
-
+        // the 'settings_test.xml' actually contains 4 server tags, but we remove all and only inject the ones managed
+        // by the plugin
+        assertEquals(
+                SERVER_COUNT,
+                nodes.getLength(),
+                "there is not the same number of server tags anymore in the settings.xml");
     }
 
     @Test
-    public void testSettingsXmlIsNotChangedWithoutCredentialsWhenReplaceTrue() throws Exception {
+    void testSettingsXmlIsNotChangedWithoutCredentialsWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
 
-        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<>();
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
-        List<String> tempFiles = new ArrayList<String>();
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.TRUE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        List<String> tempFiles = new ArrayList<>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(
+                settingsContent, Boolean.TRUE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
 
-        Assert.assertEquals("no changes should have been made to the settings", settingsContent, replacedContent);
-
+        assertEquals(settingsContent, replacedContent, "no changes should have been made to the settings");
     }
 
     @Test
-    public void testSettingsXmlIsNotChangedWithoutCredentialsWhenReplaceFalse() throws Exception {
+    void testSettingsXmlIsNotChangedWithoutCredentialsWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
 
-        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<>();
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
-        List<String> tempFiles = new ArrayList<String>();
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        List<String> tempFiles = new ArrayList<>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(
+                settingsContent, Boolean.FALSE, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
 
-        Assert.assertEquals("no changes should have been made to the settings", settingsContent, replacedContent);
-
+        assertEquals(settingsContent, replacedContent, "no changes should have been made to the settings");
     }
 
     @Issue("JENKINS-39991")
     @Test
-    public void testIfServerElementAreKeptWhenMatchCredentialsWhenReplaceFalse() throws Exception {
-        testIfServerElementAreKeptWhenMatchCredentials(false);
-
+    void testIfServerElementAreKeptWhenMatchCredentialsWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
+        testIfServerElementAreKeptWhenMatchCredentials(jenkins, false);
     }
 
     @Issue("JENKINS-39991")
     @Test
-    public void testIfServerElementAreKeptWhenMatchCredentialsWhenReplaceTrue() throws Exception {
-        testIfServerElementAreKeptWhenMatchCredentials(true);
+    void testIfServerElementAreKeptWhenMatchCredentialsWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
+        testIfServerElementAreKeptWhenMatchCredentials(jenkins, true);
     }
 
-    private void testIfServerElementAreKeptWhenMatchCredentials(boolean replaceAll) throws Exception {
+    private void testIfServerElementAreKeptWhenMatchCredentials(JenkinsRule jenkins, boolean replaceAll)
+            throws Exception {
         final String serverId = "jenkins-39991";
 
-        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<String, StandardUsernameCredentials>();
-        serverId2Credentials.put(serverId, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
+        Map<String, StandardUsernameCredentials> serverId2Credentials = new HashMap<>();
+        serverId2Credentials.put(
+                serverId,
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my*", "some desc", "peter", PWD));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
-        List<String> tempFiles = new ArrayList<String>();
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, replaceAll, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.xml"));
+        List<String> tempFiles = new ArrayList<>();
+        final String replacedContent = CredentialsHelper.fillAuthentication(
+                settingsContent, replaceAll, serverId2Credentials, jenkins.jenkins.createPath("tmp"), tempFiles);
 
         // read original server settings
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(settingsContent)));
+        Document doc = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader(settingsContent)));
         XPath xpath = XPathFactory.newInstance().newXPath();
-        Node server = (Node) xpath.evaluate("/settings/servers/server[id='" + serverId + "']", doc, XPathConstants.NODE);
+        Node server =
+                (Node) xpath.evaluate("/settings/servers/server[id='" + serverId + "']", doc, XPathConstants.NODE);
         String filePermissions = xpath.evaluate("filePermissions", server);
         String directoryPermissions = xpath.evaluate("directoryPermissions", server);
         String configuration = xpath.evaluate("configuration", server);
 
         // ensure it is still a valid XML document
-        doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(replacedContent)));
+        doc = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new StringReader(replacedContent)));
         // locate the node(s)
         xpath = XPathFactory.newInstance().newXPath();
 
         server = (Node) xpath.evaluate("/settings/servers/server[id='" + serverId + "']", doc, XPathConstants.NODE);
-        Assert.assertEquals("password is not at the correct location", PWD, xpath.evaluate("password", server));
-        Assert.assertEquals("username is not set correct", "peter", xpath.evaluate("username", server));
-        Assert.assertEquals("filePermissions is not set correct", filePermissions, xpath.evaluate("filePermissions", server));
-        Assert.assertEquals("directoryPermissions is not set correct", directoryPermissions, xpath.evaluate("directoryPermissions", server));
-        Assert.assertEquals("configuration is not set correct", configuration.trim(), xpath.evaluate("configuration", server).trim());
+        assertEquals(PWD, xpath.evaluate("password", server), "password is not at the correct location");
+        assertEquals("peter", xpath.evaluate("username", server), "username is not set correct");
+        assertEquals(filePermissions, xpath.evaluate("filePermissions", server), "filePermissions is not set correct");
+        assertEquals(
+                directoryPermissions,
+                xpath.evaluate("directoryPermissions", server),
+                "directoryPermissions is not set correct");
+        assertEquals(
+                configuration.trim(),
+                xpath.evaluate("configuration", server).trim(),
+                "configuration is not set correct");
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/properties/PropertiesConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/properties/PropertiesConfigTest.java
@@ -3,53 +3,61 @@ package org.jenkinsci.plugins.configfiles.properties;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import java.util.Collections;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.properties.security.PropertiesCredentialMapping;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import java.util.Collections;
-
-public class PropertiesConfigTest {
-
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+@WithJenkins
+class PropertiesConfigTest {
 
     @Test
-    public void withCredentials() throws Exception {
+    void withCredentials(JenkinsRule r) throws Exception {
         // Smokes with full replace:
-        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
-        GlobalConfigFiles.get().save(new PropertiesConfig("gradle", "gradle", "", "myprop=", true, Collections.singletonList(new PropertiesCredentialMapping("myprop", "creds"))));
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .add(new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.GLOBAL, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
+        GlobalConfigFiles.get()
+                .save(new PropertiesConfig(
+                        "gradle",
+                        "gradle",
+                        "",
+                        "myprop=",
+                        true,
+                        Collections.singletonList(new PropertiesCredentialMapping("myprop", "creds"))));
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(
-                String.join("\n", 
-                  "node {",
-                  "  configFileProvider([configFile(fileId: 'gradle', ",
-                  "                                 variable: 'SETTINGS')]) {",
-                  "    String content = readFile(env.SETTINGS)",
-                  "    if (currentBuild.id == 1) { // only the first build will have the secret" ,
-                  "      assert content.contains('myprop=bot-user-s3cr3t')",
-                  "    }",
-                  "    echo content",
-                  "  }",
-                  "}"),
+                String.join(
+                        "\n",
+                        "node {",
+                        "  configFileProvider([configFile(fileId: 'gradle', ",
+                        "                                 variable: 'SETTINGS')]) {",
+                        "    String content = readFile(env.SETTINGS)",
+                        "    if (currentBuild.id == 1) { // only the first build will have the secret",
+                        "      assert content.contains('myprop=bot-user-s3cr3t')",
+                        "    }",
+                        "    echo content",
+                        "  }",
+                        "}"),
                 true));
         WorkflowRun b1 = r.buildAndAssertSuccess(p);
         r.assertLogContains("myprop=****", b1);
         r.assertLogNotContains("myprop=bot-user-s3cr3t", b1);
         // Missing credentials. Currently treated as nonfatal:
-        SystemCredentialsProvider.getInstance().getCredentials().set(0, new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .set(
+                        0,
+                        new UsernamePasswordCredentialsImpl(
+                                CredentialsScope.SYSTEM, "creds", "", "bot-user-name", "bot-user-s3cr3t"));
         WorkflowRun b2 = r.buildAndAssertSuccess(p);
         r.assertLogContains("Could not find credentials [creds] for p #2", b2);
-        r.assertLogContains("myprop="+System.lineSeparator(), b2);
+        r.assertLogContains("myprop=" + System.lineSeparator(), b2);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/properties/security/CredentialsHelperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/properties/security/CredentialsHelperTest.java
@@ -1,90 +1,110 @@
 package org.jenkinsci.plugins.configfiles.properties.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class CredentialsHelperTest {
+@WithJenkins
+class CredentialsHelperTest {
 
-    private final static String PWD = "bot-user-s3cr3t";
-
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    private static final String PWD = "bot-user-s3cr3t";
 
     @Test
-    public void testPropertiesIsReplacedWhenReplaceTrue() throws Exception {
+    void testPropertiesIsReplacedWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
+        credentials.put(
+                "myProp",
+                new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
         final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.TRUE, credentials);
 
-        Assert.assertTrue("replaced settings_test.properties must contain new password", replacedContent.contains(PWD));
+        assertTrue(replacedContent.contains(PWD), "replaced settings_test.properties must contain new password");
     }
 
     @Test
-    public void testPropertiesIsNotReplacedWhenReplaceFalse() throws Exception {
+    void testPropertiesIsNotReplacedWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
+        credentials.put(
+                "myProp",
+                new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
+        final String replacedContent =
+                CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
 
-        Assert.assertEquals("no changes should have been made to the settings_test.properties", settingsContent, replacedContent);
+        assertEquals(
+                settingsContent, replacedContent, "no changes should have been made to the settings_test.properties");
     }
 
     @Test
-    public void testPropertiesIsAddedWhenReplaceTrue() throws Exception {
+    void testPropertiesIsAddedWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
+        credentials.put(
+                "myNewProp",
+                new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
         final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.TRUE, credentials);
 
-        Assert.assertTrue("replaced settings_test.properties must contain new password", replacedContent.contains(PWD));
+        assertTrue(replacedContent.contains(PWD), "replaced settings_test.properties must contain new password");
     }
 
     @Test
-    public void testPropertiesIsAddedWhenReplaceFalse() throws Exception {
+    void testPropertiesIsAddedWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
-        credentials.put("myNewProp", new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
+        credentials.put(
+                "myNewProp",
+                new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.SYSTEM, "my-credentials", "some desc", "bot-user-name", PWD));
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
 
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
+        final String replacedContent =
+                CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
 
-        Assert.assertTrue("replaced settings_test.properties must contain new password", replacedContent.contains(PWD));
+        assertTrue(replacedContent.contains(PWD), "replaced settings_test.properties must contain new password");
     }
 
     @Test
-    public void testSettingsPropertiesIsNotChangedWithoutCredentialsWhenReplaceTrue() throws Exception {
+    void testSettingsPropertiesIsNotChangedWithoutCredentialsWhenReplaceTrue(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
         final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.TRUE, credentials);
 
-        Assert.assertEquals("no changes should have been made to the settings", settingsContent, replacedContent);
+        assertEquals(settingsContent, replacedContent, "no changes should have been made to the settings");
     }
 
     @Test
-    public void testSettingsPropertiesIsNotChangedWithoutCredentialsWhenReplaceFalse() throws Exception {
+    void testSettingsPropertiesIsNotChangedWithoutCredentialsWhenReplaceFalse(JenkinsRule jenkins) throws Exception {
         Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
 
-        final String settingsContent = IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
-        final String replacedContent = CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
+        final String settingsContent =
+                IOUtils.toString(CredentialsHelperTest.class.getResourceAsStream("/settings_test.properties"));
+        final String replacedContent =
+                CredentialsHelper.fillAuthentication(settingsContent, Boolean.FALSE, credentials);
 
-        Assert.assertEquals("no changes should have been made to the settings", settingsContent, replacedContent);
+        assertEquals(settingsContent, replacedContent, "no changes should have been made to the settings");
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionChecker.java
@@ -1,17 +1,17 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.security.Permission;
-import org.springframework.security.access.AccessDeniedException;
-import java.util.function.Supplier;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.security.Permission;
+import java.util.function.Supplier;
+import org.springframework.security.access.AccessDeniedException;
 
 /**
  * A class to run pieces of code with a certain user and assert either the code runs successfully, without even worrying
- * about the result, or the code fails with an {@link AccessDeniedException} with the specified {@link Permission} reason. 
+ * about the result, or the code fails with an {@link AccessDeniedException} with the specified {@link Permission} reason.
  */
 public class PermissionChecker extends ProtectedCodeRunner<Void> {
     /**
@@ -34,7 +34,9 @@ public class PermissionChecker extends ProtectedCodeRunner<Void> {
         if (t instanceof AccessDeniedException) {
             assertThat(t.getMessage(), containsString(permission.group.title + "/" + permission.name));
         } else {
-            fail(String.format("The code run by %s didn't throw an AccessDeniedException with %s. If failed with the unexpected throwable: %s", getUser(), permission, t));
+            fail(String.format(
+                    "The code run by %s didn't throw an AccessDeniedException with %s. If failed with the unexpected throwable: %s",
+                    getUser(), permission, t));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionCheckerTests.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/PermissionCheckerTests.java
@@ -1,27 +1,32 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
 import jenkins.model.Jenkins;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PermissionCheckerTests {
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+@WithJenkins
+class PermissionCheckerTests {
 
-    @Before
-    public void setUpAuthorizationAndProject() {
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setUpAuthorizationAndProject(JenkinsRule r) {
+        this.r = r;
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
-                grant(Jenkins.READ).everywhere().to("reader").
-                grant(Jenkins.ADMINISTER).everywhere().to("administer")
-        );
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ)
+                .everywhere()
+                .to("reader")
+                .grant(Jenkins.ADMINISTER)
+                .everywhere()
+                .to("administer"));
     }
-    
+
     @Test
-    public void protectedCodeCheckerTest() {
+    void protectedCodeCheckerTest() {
         Runnable run = () -> r.jenkins.checkPermission(Jenkins.ADMINISTER);
 
         // The administer passes

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunner.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/ProtectedCodeRunner.java
@@ -1,13 +1,12 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-
 import java.util.function.Supplier;
-
-import static org.junit.Assert.fail;
 
 /**
  * Class to run a code returning something with a specific user. You can get the result or the {@link Throwable} thrown
@@ -17,6 +16,7 @@ import static org.junit.Assert.fail;
 public class ProtectedCodeRunner<Result> {
     @NonNull
     private final Supplier<Result> code;
+
     @NonNull
     private String user;
 
@@ -39,20 +39,23 @@ public class ProtectedCodeRunner<Result> {
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName(user))) {
             return code.get();
         } catch (Throwable t) {
-            fail(String.format("The code executed by %s didn't run successfully. The throwable thrown is: %s", user, t));
+            fail(String.format(
+                    "The code executed by %s didn't run successfully. The throwable thrown is: %s", user, t));
             return null;
         }
     }
 
     /**
-     * We run the code expecting an exception to be thrown. If it's not the case, the test fails with a descriptive 
+     * We run the code expecting an exception to be thrown. If it's not the case, the test fails with a descriptive
      * message.
      * @return The {@link Throwable} thrown by the execution.
      */
     public Throwable getThrowable() {
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName(user))) {
             Result result = code.get();
-            fail(String.format("The code executed by %s was successful but we were expecting it to fail. The result of the execution was: %s", user, result));
+            fail(String.format(
+                    "The code executed by %s was successful but we were expecting it to fail. The result of the execution was: %s",
+                    user, result));
             return null;
         } catch (Throwable t) {
             return t;

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2002Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2002Test.java
@@ -1,43 +1,40 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import hudson.util.VersionNumber;
+import java.util.concurrent.atomic.AtomicReference;
+import jenkins.model.GlobalConfiguration;
 import org.hamcrest.CoreMatchers;
 import org.htmlunit.html.HtmlAnchor;
 import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlPage;
-import hudson.util.VersionNumber;
-import jenkins.model.GlobalConfiguration;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.HtmlElementUtil;
 import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
-public class Security2002Test {
+@WithJenkins
+class Security2002Test {
     private static final String CONFIG_ID = "ConfigFilesTestId";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    
     @Test
     @Issue("SECURITY-2202")
-    public void xssPrevention() throws Exception { 
-        
+    void xssPrevention(JenkinsRule j) throws Exception {
+
         // ----------
         // Create a new configuration
-        GlobalConfigFiles store = j.getInstance().getExtensionList(GlobalConfiguration.class).get(GlobalConfigFiles.class);
+        GlobalConfigFiles store =
+                j.getInstance().getExtensionList(GlobalConfiguration.class).get(GlobalConfigFiles.class);
         assertNotNull(store);
         assertThat(store.getConfigs(), empty());
-        
+
         CustomConfig config = new CustomConfig(CONFIG_ID, "My configuration", "comment", "content");
         store.save(config);
 
@@ -54,7 +51,9 @@ public class Security2002Test {
         // Clicking the button works
         // If we click on the link, it goes via POST, therefore it removes it successfully
         HtmlPage configFiles = wc.goTo("configfiles");
-        HtmlAnchor removeAnchor = configFiles.getDocumentElement().getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
+        HtmlAnchor removeAnchor = configFiles
+                .getDocumentElement()
+                .getFirstByXPath("//a[contains(@data-url, 'removeConfig?id=" + CONFIG_ID + "')]");
 
         if (j.jenkins.getVersion().isOlderThan(new VersionNumber("2.415"))) {
             AtomicReference<Boolean> confirmCalled = new AtomicReference<>(false);

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2204Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2204Test.java
@@ -1,49 +1,51 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import hudson.FilePath;
-import org.apache.commons.io.IOUtils;
-import org.hamcrest.core.StringContains;
-import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.xml.sax.SAXParseException;
-
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static com.ibm.icu.impl.Assert.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
-public class Security2204Test {
-    @Rule
-    public JenkinsRule rr = new JenkinsRule();
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.FilePath;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.core.StringContains;
+import org.jenkinsci.plugins.configfiles.maven.security.CredentialsHelper;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.xml.sax.SAXParseException;
+
+@WithJenkins
+class Security2204Test {
 
     private static final String NEW_PASSWORD = "PASSWORD-REPLACED";
-    
+
     /**
      * If we use an xml with an external entity, the parser fails to read it.
      * @throws Exception if an error happens while reading the xml or parsing it and it's not the expected one.
      */
     @Test
     @Issue("SECURITY-2204")
-    public void xxeOnMavenXMLDetected() throws Exception {
+    void xxeOnMavenXMLDetected(JenkinsRule rr) throws Exception {
         try {
-            tryToReplaceAuthOnXml("settings-xxe.xml");
+            tryToReplaceAuthOnXml(rr, "settings-xxe.xml");
         } catch (SAXParseException e) {
-            assertThat(e.getMessage(), containsString("DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true."));
+            assertThat(
+                    e.getMessage(),
+                    containsString(
+                            "DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true."));
             return;
             // The console also prints the message out:
-            // [Fatal Error] :5:13: External Entity: Failed to read external document 'oob.xml', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.
+            // [Fatal Error] :5:13: External Entity: Failed to read external document 'oob.xml', because 'http' access
+            // is not allowed due to restriction set by the accessExternalDTD property.
         }
         fail("The fillAuthentication should have detected the XXE but it's not the case");
     }
@@ -55,20 +57,22 @@ public class Security2204Test {
      */
     @Test
     @Issue("SECURITY-2204")
-    public void mavenSettingsAuthFilled() throws Exception {
+    void mavenSettingsAuthFilled(JenkinsRule rr) throws Exception {
         String settings = "settings.xml";
-        String settingsReplaced = tryToReplaceAuthOnXml(settings);
+        String settingsReplaced = tryToReplaceAuthOnXml(rr, settings);
         assertThat(settingsReplaced, not(StringContains.containsString("whatever-password-because-its-replaced")));
         assertThat(settingsReplaced, StringContains.containsString(NEW_PASSWORD));
     }
-    
-    private String tryToReplaceAuthOnXml(String file) throws Exception {
-        String mavenSettingsContent = IOUtils.toString(this.getClass().getResource(file), StandardCharsets.UTF_8);
-        Map<String, StandardUsernameCredentials> credentials = new HashMap<String, StandardUsernameCredentials>();
 
-        StandardUsernameCredentials usernameCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "credentialId", "user", "credential description", NEW_PASSWORD);
+    private String tryToReplaceAuthOnXml(JenkinsRule rr, String file) throws Exception {
+        String mavenSettingsContent = IOUtils.toString(this.getClass().getResource(file), StandardCharsets.UTF_8);
+        Map<String, StandardUsernameCredentials> credentials = new HashMap<>();
+
+        StandardUsernameCredentials usernameCredentials = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "credentialId", "user", "credential description", NEW_PASSWORD);
         credentials.put("credential", usernameCredentials);
         List<String> tempFiles = new ArrayList<>();
-        return CredentialsHelper.fillAuthentication(mavenSettingsContent, true, credentials, new FilePath(rr.jenkins.root), tempFiles);
+        return CredentialsHelper.fillAuthentication(
+                mavenSettingsContent, true, credentials, new FilePath(rr.jenkins.root), tempFiles);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2254Test.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/sec/Security2254Test.java
@@ -1,5 +1,9 @@
 package org.jenkinsci.plugins.configfiles.sec;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -15,114 +19,112 @@ import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.ListBoxModel;
+import java.util.function.Supplier;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import java.util.function.Supplier;
+@WithJenkins
+class Security2254Test {
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-
-public class Security2254Test {
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
-    
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
-    
+    private JenkinsRule r;
     private WorkflowJob project;
     private Folder folder;
-    
-    @Before
-    public void setUpAuthorizationAndProject() throws Exception {
+
+    @BeforeEach
+    void setUpAuthorizationAndProject(JenkinsRule r) throws Exception {
+        this.r = r;
         // A folder and a project inside
         folder = r.jenkins.createProject(Folder.class, "f");
         project = folder.createProject(WorkflowJob.class, "p");
-        
+
         // The permissions
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
-        
+
         // Everyone can read
         strategy.grant(Jenkins.READ).everywhere().toEveryone();
-        
+
         // Reader. No permissions to manage credentials
         strategy.grant(Item.READ).everywhere().to("reader");
-        
+
         // accredited with own credentials store and able to use them in project
         strategy.grant(Item.EXTENDED_READ).onItems(project).to("accredited");
         strategy.grant(CredentialsProvider.USE_ITEM).onItems(project).to("accredited");
-        
+
         // Project configurer on project
         strategy.grant(Item.CONFIGURE).onItems(project).to("projectConfigurer");
-        
+
         // Folder configurer
         strategy.grant(Item.CONFIGURE).onItems(folder).to("folderConfigurer");
-        
+
         // Administer
         strategy.grant((Jenkins.ADMINISTER)).everywhere().to("administer");
-        
+
         r.jenkins.setAuthorizationStrategy(strategy);
-        
+
         // A system global credential
-        SystemCredentialsProvider.getInstance().getCredentials().add(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "systemCred", "", "systemUser", "systemPassword"));
-        
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .add(new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.GLOBAL, "systemCred", "", "systemUser", "systemPassword"));
+
         // The credentials in folder and for accredited
         CredentialsStore folderStore = getFolderStore(folder);
-        UsernamePasswordCredentialsImpl folderCredential =
-                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "folderCred", "description", "folderUser",
-                        "folderPassword");
+        UsernamePasswordCredentialsImpl folderCredential = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "folderCred", "description", "folderUser", "folderPassword");
         folderStore.addCredentials(Domain.global(), folderCredential);
 
         // A credential for accredited
         CredentialsStore userStore = getUserStore(User.getOrCreateByIdOrFullName("accredited"));
-        UsernamePasswordCredentialsImpl userCredential =
-                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "userCred", "description", "accreditedUser",
-                        "accreditedPassword");
+        UsernamePasswordCredentialsImpl userCredential = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "userCred", "description", "accreditedUser", "accreditedPassword");
         // SYSTEM cannot add credentials to the user store
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName("accredited"))) {
             userStore.addCredentials(Domain.global(), userCredential);
         }
     }
-    
+
     @Test
     @Issue("SECURITY-2254")
-    public void fillCredentialIdItemsForServer() throws Exception {
+    void fillCredentialIdItemsForServer() throws Exception {
         final String CURRENT = "current-value";
-        
+
         // Code called from global pages
         Supplier<ListBoxModel> systemCredentialListSupplier = () -> {
-            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl) Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
+            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl)
+                    Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
             return descriptor.doFillCredentialsIdItems(r.jenkins, null, CURRENT);
         };
-        ProtectedCodeRunner<ListBoxModel> globalChecker = new ProtectedCodeRunner<>(systemCredentialListSupplier, "user-will-be-replaced");
+        ProtectedCodeRunner<ListBoxModel> globalChecker =
+                new ProtectedCodeRunner<>(systemCredentialListSupplier, "user-will-be-replaced");
 
         // Code called from a project
         Supplier<ListBoxModel> projectCredentialListSupplier = () -> {
-            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl) Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
+            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl)
+                    Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
             return descriptor.doFillCredentialsIdItems(folder, project, CURRENT);
         };
-        ProtectedCodeRunner<ListBoxModel> projectChecker = new ProtectedCodeRunner<>(projectCredentialListSupplier, "user-will-be-replaced");
-        
+        ProtectedCodeRunner<ListBoxModel> projectChecker =
+                new ProtectedCodeRunner<>(projectCredentialListSupplier, "user-will-be-replaced");
+
         // Code called from a folder
         Supplier<ListBoxModel> folderCredentialListSupplier = () -> {
-            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl) Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
+            ServerCredentialMapping.DescriptorImpl descriptor = (ServerCredentialMapping.DescriptorImpl)
+                    Jenkins.get().getDescriptorOrDie(ServerCredentialMapping.class);
             return descriptor.doFillCredentialsIdItems(r.jenkins, folder, CURRENT);
         };
-        ProtectedCodeRunner<ListBoxModel> folderChecker = new ProtectedCodeRunner<>(folderCredentialListSupplier, "user-will-be-replaced");
+        ProtectedCodeRunner<ListBoxModel> folderChecker =
+                new ProtectedCodeRunner<>(folderCredentialListSupplier, "user-will-be-replaced");
 
         ListBoxModel result;
-        
+
         // Reader doesn't get the list of credentials
         result = globalChecker.withUser("reader").getResult();
         assertThat(result, hasSize(1));
@@ -133,8 +135,9 @@ public class Security2254Test {
         assertThat(result, hasSize(2));
         assertThat(result.get(1).value, equalTo("systemCred"));
 
-        // accredited see system global and folder ones. Their own credentials are not available because the 
-        // gathering of the credentials is used by ACL.SYSTEM. See: https://github.com/jenkinsci/config-file-provider-plugin/blob/master/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping.java#L64
+        // accredited see system global and folder ones. Their own credentials are not available because the
+        // gathering of the credentials is used by ACL.SYSTEM. See:
+        // https://github.com/jenkinsci/config-file-provider-plugin/blob/master/src/main/java/org/jenkinsci/plugins/configfiles/maven/security/ServerCredentialMapping.java#L64
         // So there is no visibility of their own credentials while configuring the project.
         result = projectChecker.withUser("accredited").getResult();
         assertThat(result, hasSize(3));
@@ -146,13 +149,13 @@ public class Security2254Test {
         assertThat(result, hasSize(3));
         assertThat(result.get(1).value, equalTo("folderCred")); // system, folder
         assertThat(result.get(2).value, equalTo("systemCred")); // project
-        
+
         // Folder configurer, without access to the project cannot get them
         result = globalChecker.withUser("folderConfigurer").getResult();
         assertThat(result, hasSize(1));
         assertThat(result.get(0).value, equalTo(CURRENT));
     }
-    
+
     private CredentialsStore getFolderStore(Folder f) {
         return getCredentialStore(f, FolderCredentialsProvider.class);
     }
@@ -160,7 +163,7 @@ public class Security2254Test {
     private CredentialsStore getUserStore(User u) {
         return getCredentialStore(u, UserCredentialsProvider.class);
     }
-    
+
     private CredentialsStore getCredentialStore(ModelObject object, Class<? extends CredentialsProvider> clazz) {
         Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(object);
         CredentialsStore folderStore = null;
@@ -172,5 +175,4 @@ public class Security2254Test {
         }
         return folderStore;
     }
-    
 }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations
* Migrate assertions
* Cleanup assertions
* Remove public visibility of test classes and methods

There is once exception in `org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapperWorkflowTest#withTempFilesAfterRestart` that will remain as a JUnit 4 test. Currently I do not see a way to migrate it due to the usage of `RestartableJenkinsRule` and `SemaphoreStep`.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewd.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

