### PR TITLE
Reduce Windows flakiness of Maven job tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/buildwrapper/ConfigFileBuildWrapperTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.configfiles.buildwrapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.maven.MavenModuleSet;
 import hudson.model.*;
@@ -63,6 +64,10 @@ class ConfigFileBuildWrapperTest {
 
         j.assertBuildStatus(
                 Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        if (Functions.isWindows()) {
+            // Wait before exiting the test so that files close before cleanup
+            Thread.sleep(3011);
+        }
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsCredentialsTest.java
@@ -10,6 +10,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenModuleSetBuild;
@@ -99,6 +100,10 @@ class MvnSettingsCredentialsTest {
         j.assertLogNotContains("<username>dude</username>", build);
         j.assertLogContains("<username>****</username>", build);
         j.assertLogContains("<password>****</password>", build);
+        if (Functions.isWindows()) {
+            // Wait before exiting the test so that files close before cleanup
+            Thread.sleep(3011);
+        }
     }
 
     private static final class DelegatingMvnSettingsProvider extends MvnSettingsProvider {

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/MvnSettingsProviderTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.configfiles.maven.job;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import hudson.Functions;
 import hudson.maven.MavenModuleSet;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
@@ -87,6 +88,10 @@ class MvnSettingsProviderTest {
         jenkins.assertEqualDataBoundBeans(p.getGlobalSettings(), s2);
         assertNotSame(p.getSettings(), s1);
         assertNotSame(p.getGlobalSettings(), s2);
+        if (Functions.isWindows()) {
+            // Wait before exiting the test so that files close before cleanup
+            Thread.sleep(3011);
+        }
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
+++ b/src/test/java/org/jenkinsci/plugins/configfiles/maven/job/SettingsEnvVarTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.configfiles.maven.job;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.maven.MavenModuleSet;
 import hudson.model.AbstractBuild;
@@ -57,6 +58,10 @@ class SettingsEnvVarTest {
 
         j.assertBuildStatus(
                 Result.SUCCESS, p.scheduleBuild2(0, new UserIdCause()).get());
+        if (Functions.isWindows()) {
+            // Wait before exiting the test so that files close before cleanup
+            Thread.sleep(3011);
+        }
     }
 
     private static final class VerifyBuilder extends Builder {


### PR DESCRIPTION
## Reduce Windows flakiness of Maven job tests

Wait before exiting a test that uses MavenModuleSet so that files will be closed and the temporary directories can be deleted.  A similar issue was seen in: 

* https://github.com/jenkinsci/dashboard-view-plugin/pull/417

### Testing done

Confirmed that `mvn clean verify` passes on my Linux computer.  Confirmed that ci.jenkins.io passed builds 6 times after these changes were complete.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
