### PR TITLE
Adapt configuration pages to jenkinsci/jenkins#11222

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.504</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.555</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <hpi.compatibleSinceVersion>2.15</hpi.compatibleSinceVersion>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     </properties>
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5622.vc9c3051619f5</version>
+                <version>6549.v96f8c826373f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
+++ b/src/main/java/org/jenkinsci/plugins/configfiles/ConfigFilesManagement.java
@@ -180,7 +180,7 @@ public class ConfigFilesManagement extends ManagementLink implements ConfigFiles
         Config config = store.getById(configId);
         req.setAttribute("contentType", config.getProvider().getContentType());
         req.setAttribute("config", config);
-        req.getView(this, JELLY_RESOURCES_PATH + "show.jelly").forward(req, rsp);
+        req.getView(this, "show.jelly").forward(req, rsp);
     }
 
     /**
@@ -199,7 +199,7 @@ public class ConfigFilesManagement extends ManagementLink implements ConfigFiles
         req.setAttribute("contentType", config.getProvider().getContentType());
         req.setAttribute("config", config);
         req.setAttribute("provider", config.getProvider());
-        req.getView(this, JELLY_RESOURCES_PATH + "edit.jelly").forward(req, rsp);
+        req.getView(this, "edit.jelly").forward(req, rsp);
     }
 
     /**
@@ -231,7 +231,7 @@ public class ConfigFilesManagement extends ManagementLink implements ConfigFiles
             checkPermission(Jenkins.MANAGE);
             req.setAttribute("providers", ConfigProvider.all());
             req.setAttribute("configId", configId);
-            req.getView(this, JELLY_RESOURCES_PATH + "selectprovider.jelly").forward(req, rsp);
+            req.getView(this, "selectprovider.jelly").forward(req, rsp);
             return;
         }
 
@@ -251,14 +251,14 @@ public class ConfigFilesManagement extends ManagementLink implements ConfigFiles
         config.setProviderId(provider.getProviderId());
         req.setAttribute("config", config);
 
-        req.getView(this, JELLY_RESOURCES_PATH + "edit.jelly").forward(req, rsp);
+        req.getView(this, "edit.jelly").forward(req, rsp);
     }
 
     public void doSelectProvider(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         // permission handled in getTarget
         req.setAttribute("providers", ConfigProvider.all());
         req.setAttribute("configId", UUID.randomUUID().toString());
-        req.getView(this, JELLY_RESOURCES_PATH + "selectprovider.jelly").forward(req, rsp);
+        req.getView(this, "selectprovider.jelly").forward(req, rsp);
     }
 
     private void checkPermission(Permission permission) {

--- a/src/main/resources/lib/configfiles/configfiles.jelly
+++ b/src/main/resources/lib/configfiles/configfiles.jelly
@@ -29,58 +29,43 @@ THE SOFTWARE.
     <st:adjunct includes="org.jenkinsci.plugins.configfiles.styles"/>
     <j:set var="groupedConfigs" value="${attrs.groupedConfigs}"/>
 
-    <div class="excerpt">
-
-        <table class="jenkins-table cfp-table">
-            <j:forEach var="pEntry" items="${groupedConfigs}">
-                <tbody>
-                    <tr class="cfp-table__section-header cfp-table__section-header--title">
-                        <td colspan="6" >
-                            ${pEntry.key.displayName}
+    <j:forEach var="pEntry" items="${groupedConfigs}">
+        <h2>${pEntry.key.displayName}</h2>
+        <table class="jenkins-table jenkins-table--medium sortable">
+            <thead>
+                <tr>
+                    <th scope="col">${%Name}</th>
+                    <th scope="col">${%ID}</th>
+                    <th scope="col">${%Comment}</th>
+                    <th scope="col">${%Content Type}</th>
+                    <th scope="col" />
+                    <th scope="col" />
+                </tr>
+            </thead>
+            <tbody>
+                <j:forEach var="t" items="${pEntry.value}">
+                    <tr>
+                        <td>
+                            <a href="editConfig?id=${t.id}">${t.name}</a>
+                        </td>
+                        <td>${t.id}</td>
+                        <td>${t.comment}</td>
+                        <td>${t.contentType}</td>
+                        <td class="jenkins-table__cell jenkins-table__cell--tight">
+                            <a href="editConfig?id=${t.id}">
+                                <l:icon tooltip="${%Edit script} ${t.name}" src="symbol-create-outline plugin-ionicons-api"
+                                        class="icon-md"/>
+                            </a>
+                        </td>
+                        <td class="jenkins-table__cell jenkins-table__cell--tight">
+                            <l:confirmationLink href="removeConfig?id=${t.id}" post="true" message="Sure you want to delete [${t.name}]?">
+                                <l:icon tooltip="${%Remove script} ${t.name}" src="symbol-trash-outline plugin-ionicons-api"
+                                        class="icon-md"/>
+                            </l:confirmationLink>
                         </td>
                     </tr>
-                    <tr class="cfp-table__section-header cfp-table__section-header--fields">
-                        <td class="jenkins-table__cell--tight cfp-table__icon">
-                            ${%E}
-                        </td>
-                        <td class="jenkins-table__cell--tight cfp-table__icon">
-                            ${%D}
-                        </td>
-                        <td>${%Name}</td>
-                        <td>${%ID}</td>
-                        <td>${%Comment}</td>
-                        <td>${%Content Type}</td>
-                    </tr>
-                    <j:forEach var="t" items="${pEntry.value}">
-                        <tr>
-                            <td class="jenkins-table__cell--tight cfp-table__icon">
-                                <a href="editConfig?id=${t.id}">
-                                    <l:icon tooltip="${%Edit script} ${t.name}" src="symbol-create-outline plugin-ionicons-api"
-                                         class="icon-md"/>
-                                </a>
-                            </td>
-                            <td class="jenkins-table__cell--tight cfp-table__icon">
-                                <l:confirmationLink href="removeConfig?id=${t.id}" post="true" message="Sure you want to delete [${t.name}]?">
-                                    <l:icon tooltip="${%Remove script} ${t.name}" src="symbol-trash-outline plugin-ionicons-api"
-                                            class="icon-md"/>
-                                </l:confirmationLink>
-                            </td>
-                            <td>
-                                ${t.name}
-                            </td>
-                            <td>
-                                ${t.id}
-                            </td>
-                            <td>
-                                ${t.comment}
-                            </td>
-                            <td>
-                                ${t.contentType}
-                            </td>
-                        </tr>
-                    </j:forEach>
-                </tbody>
-            </j:forEach>
+                </j:forEach>
+            </tbody>
         </table>
-    </div>
+    </j:forEach>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/configfiles.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/configfiles.properties
@@ -1,0 +1,3 @@
+Config\ File\ Management=Config File Management
+Add\ a\ new\ Config=Add a new Config
+intro=You can edit or remove your configuration files

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2011, Dominik Bartholdi
+Copyright (c) 2026, Antoine Neveux
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.jelly
@@ -1,0 +1,55 @@
+<!--
+The MIT License
+
+Copyright (c) 2011, Dominik Bartholdi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<l:settings-subpage title="${%Edit Configuration File}" permission="${app.MANAGE}" noDefer="true">
+		<j:set var="config" value="${config}"/>
+		<j:set var="contentType" value="${contentType}"/>
+		<j:set var="instance" value="${instance}"/>
+		<f:form method="post" action="saveConfig">
+		   <f:section title="${%The configuration}" name="config">
+		   		<input type="hidden" name="stapler-class" value="${config.class.name}" />
+		   		<j:choose>
+		          <j:when test="${config.class.name == 'org.jenkinsci.lib.configprovider.model.Config'}">
+		            	<st:include page="edit-config.jelly" from="${instance}"/>
+		          </j:when>
+		          <j:otherwise>
+		            	<st:include page="edit-config.jelly" from="${config}" it="${config}"/>
+		          </j:otherwise>
+		        </j:choose>
+				<f:block>
+					<f:submit value="${%Submit}" />
+				</f:block>
+			</f:section>
+		</f:form>
+	</l:settings-subpage>
+	<j:if test="${contentType!=null}">
+		<st:adjunct includes="
+	        org.kohsuke.stapler.codemirror.mode.${contentType.cmMode}.${contentType.cmMode},
+	        org.kohsuke.stapler.codemirror.theme.default,
+	        org.jenkinsci.plugins.configfiles.ConfigFilesUI.setup-codemirror"/>
+		<span class="content-type-config" data-content-type="${contentType.mime}" data-read-only="false" style="display:none"/>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/edit.properties
@@ -1,0 +1,3 @@
+Edit\ Configuration\ File=Edit Configuration File
+The\ configuration=The configuration
+Submit=Submit

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2011, Dominik Bartholdi
+Copyright (c) 2026, Antoine Neveux
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.jelly
@@ -23,15 +23,9 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:cf="/lib/configfiles">
-	<l:settings-subpage title="${%Config File Management}" permission="${app.MANAGE}">
-        <div class="jenkins-buttons-row" style="margin: 1rem 0 1.5rem 0">
-            <a href="selectProvider" class="jenkins-button jenkins-button--primary">
-                <l:icon src="symbol-add" />
-                ${%Add a new Config}
-            </a>
-        </div>
-        <cf:configfiles groupedConfigs="${it.groupedConfigs}" />
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:cf="/lib/configfiles">
+	<l:settings-subpage title="${%New configuration}" permission="${app.MANAGE}" noDefer="true">
+		<j:set var="configId" value="${configId}"/>
+		<cf:selectprovider providers="${it.providers}"/>
 	</l:settings-subpage>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/selectprovider.properties
@@ -1,0 +1,1 @@
+New\ configuration=New configuration

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2011, Dominik Bartholdi
+Copyright (c) 2026, Antoine Neveux
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.jelly
@@ -1,0 +1,51 @@
+<!--
+The MIT License
+
+Copyright (c) 2011, Dominik Bartholdi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<l:settings-subpage title="${%Script details}" permission="${app.MANAGE}" noDefer="true">
+		<j:set var="config" value="${config}"/>
+		<j:set var="contentType" value="${contentType}"/>
+		<j:set var="instance" value="${instance}"/>
+		<f:form method="" action="">
+			<f:section title="${%Script details}" name="config">
+				<j:choose>
+					<j:when test="${config.class.name == 'org.jenkinsci.lib.configprovider.model.Config'}">
+						<st:include page="show-config.jelly" from="${instance}" />
+					</j:when>
+					<j:otherwise>
+						<st:include page="show-config.jelly" from="${config}" />
+					</j:otherwise>
+				</j:choose>
+			</f:section>
+		</f:form>
+	</l:settings-subpage>
+	<j:if test="${contentType!=null}">
+		<st:adjunct includes="
+	        org.kohsuke.stapler.codemirror.mode.${contentType.cmMode}.${contentType.cmMode},
+	        org.kohsuke.stapler.codemirror.theme.default,
+	        org.jenkinsci.plugins.configfiles.ConfigFilesUI.setup-codemirror"/>
+		<span class="content-type-config" data-content-type="${contentType.mime}" data-read-only="true" style="display:none"/>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/ConfigFilesManagement/show.properties
@@ -1,0 +1,1 @@
+Script\ details=Script details

--- a/src/main/resources/org/jenkinsci/plugins/configfiles/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/configfiles/Messages.properties
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 display_name=Managed files
-description=e.g. settings.xml for maven, central managed scripts, custom files, ...
+description=Manage configuration files that are provisioned to build workspaces.
 custom_provider_name=Custom file
 groovy_provider_name=Groovy file
 groovy_provider_description=a reusable groovy script


### PR DESCRIPTION
Hello :wave:

Recently, https://github.com/jenkinsci/jenkins/pull/11222 introduced a new experimental `Manage Jenkins` layout.
Plugins have to be updated for this new UI, and this PR proposes a simple fix.

## Before the Changes:

<details>
<summary>Without the new UI (`mvn hpi:run`)</summary>

<img width="1919" height="1064" alt="image" src="https://github.com/user-attachments/assets/11b6d2fc-2203-4aae-b95c-00020d61cc37" />

<img width="1919" height="1065" alt="image" src="https://github.com/user-attachments/assets/7b773bae-f246-49fa-8930-09af5c0fc6f3" />

</details>

---

<details>
<summary>With the new UI (`mvn hpi:run -Dmaven.hpi.run.jvmArgs="-Dnew-manage-jenkins.flag.defaultValue=true"`)</summary>

<img width="1919" height="1065" alt="image" src="https://github.com/user-attachments/assets/b9789097-542a-4361-ad0f-436df9235485" />

<img width="1920" height="1066" alt="image" src="https://github.com/user-attachments/assets/7bb884b0-a666-4ae5-b608-a63df0021d8e" />

<img width="1920" height="1065" alt="image" src="https://github.com/user-attachments/assets/647afe44-bb5d-4954-917b-9f0103dd0914" />

</details>

## After the Changes:

<details>
<summary>Without the new UI (`mvn hpi:run`)</summary>

<img width="1920" height="1067" alt="image" src="https://github.com/user-attachments/assets/5119ce45-e6db-4990-99d5-30c8004f97aa" />

<img width="1921" height="1067" alt="image" src="https://github.com/user-attachments/assets/a808699e-f890-41c1-b621-ae55ff6342b6" />

<img width="1919" height="1067" alt="image" src="https://github.com/user-attachments/assets/d3e0d379-0e77-427f-94f6-d8b33e4b269f" />

</details>

---

<details>
<summary>With the new UI (`mvn hpi:run -Dmaven.hpi.run.jvmArgs="-Dnew-manage-jenkins.flag.defaultValue=true"`)</summary>

<img width="1920" height="1066" alt="image" src="https://github.com/user-attachments/assets/e570b8d6-b59d-421f-bd8a-fcc729b60b82" />

<img width="1919" height="1064" alt="image" src="https://github.com/user-attachments/assets/c0b81fa4-a9a6-402b-b3f8-533237b71cd3" />

<img width="1918" height="1065" alt="image" src="https://github.com/user-attachments/assets/04f08766-c36d-4b37-a4e3-c15db3633329" />

</details>

---

This requires a bump of the Jenkins version in order to get the new UI and required fixes.
While I was at it, I modernized a bit the table that is listing the files to apply the recommendations from https://weekly.ci.jenkins.io/design-library/.

Note: `JELLY_RESOURCES_PATH` is now dead, nothing references it since we moved the views under `ConfigFilesManagement` so Stapler resolves them directly from `this`.

The `ConfigFilesUI` resource directory is in the same situation and the jelly files in it are all orphaned. Worth deleting to avoid confusion, but I thought it could be done in a follow-up PR if that makes sense.

---

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

Thanks a lot for your review! :heart: 